### PR TITLE
Change `Discrete` instance to generic

### DIFF
--- a/core/src/main/scala/cats/collections/Discrete.scala
+++ b/core/src/main/scala/cats/collections/Discrete.scala
@@ -24,11 +24,10 @@ trait Discrete[A] {
 
 object Discrete {
   implicit def integralDiscrete[@specialized(Specializable.Integral) I](
-      implicit I: Integral[I]): Discrete[I] = 
+      implicit I: Integral[I]): Discrete[I] =
   new Discrete[I] {
     import Integral.Implicits._
     override def succ(x: I): I = x + I.one
     override def pred(x: I): I = x - I.one
   }
 }
-


### PR DESCRIPTION
This is to support `Long` instances, but will also cover anything that has a `scala.Integral` instance. The `specialized` annotation means there should be no performance loss, but I haven't benchmarked.