### PR TITLE
Fixed Discrete specialization warning message

### DIFF
--- a/core/src/main/scala/cats/collections/Discrete.scala
+++ b/core/src/main/scala/cats/collections/Discrete.scala
@@ -4,7 +4,7 @@ package cats.collections
 /**
  * Represent discrete operations that can be performed on A
  */
-trait Discrete[A] {
+trait Discrete[@specialized(Specializable.Integral) A] {
 
   /**
    * Return the successor of x.


### PR DESCRIPTION
The warning was caused because the Discrete trait did not
annotate its type parameter with `@specialized`, thus the
specialization on the method would not work.

fixes #145