### PR TITLE
Add TreeList Benchmarks

### DIFF
--- a/bench/src/main/scala/TreeListBench.scala
+++ b/bench/src/main/scala/TreeListBench.scala
@@ -1,0 +1,107 @@
+package cats.collections
+package bench
+
+import org.openjdk.jmh.annotations.{Benchmark, Param, Scope, Setup, State}
+import org.openjdk.jmh.infra.Blackhole
+import scala.util.Random
+import scalaz.{IList, Diev}
+import cats._
+import cats.implicits._
+
+import scala.annotation.tailrec
+
+@State(Scope.Thread)
+class TreeListBench {
+  @Param(Array("100", "1000", "10000"))
+  var n: Int = _
+
+  var treeList: TreeList[Int] = _
+  var list: List[Int] = _
+  var vect: Vector[Int] = _
+
+  @Setup
+  def setup: Unit = {
+    list = (0 until n).toList
+    treeList = TreeList.fromList(list)
+    vect = list.toVector
+  }
+
+  @Benchmark
+  def sumList(bh: Blackhole): Unit = {
+
+    @tailrec
+    def loop(ls: List[Int], acc: Int): Int =
+      ls match {
+        case Nil => acc
+        case h :: tail => loop(tail, acc + h)
+      }
+
+    bh.consume(loop(list, 0))
+  }
+
+  @Benchmark
+  def sumVector(bh: Blackhole): Unit = {
+
+    @tailrec
+    def loop(ls: Vector[Int], acc: Int): Int =
+      if (ls.isEmpty) acc
+      else loop(ls.init, ls.last + acc)
+
+    bh.consume(loop(vect, 0))
+  }
+
+  @Benchmark
+  def sumTreeList(bh: Blackhole): Unit = {
+
+    @tailrec
+    def loop(ls: TreeList[Int], acc: Int): Int =
+      ls.uncons match {
+        case None => acc
+        case Some((h, tail)) => loop(tail, acc + h)
+      }
+
+    bh.consume(loop(treeList, 0))
+  }
+
+  @Benchmark
+  def randomAccessList(bh: Blackhole): Unit = {
+
+    val rand = new java.util.Random(42)
+    @tailrec
+    def loop(cnt: Int, acc: Int): Int = {
+      val v = list((rand.nextInt() & Int.MaxValue) % n) + acc
+      if (cnt <= 0) v
+      else loop(cnt - 1, v)
+    }
+
+    bh.consume(loop(100, 0))
+  }
+
+  @Benchmark
+  def randomAccessVector(bh: Blackhole): Unit = {
+
+    val rand = new java.util.Random(42)
+    @tailrec
+    def loop(cnt: Int, acc: Int): Int = {
+      val v = vect((rand.nextInt() & Int.MaxValue) % n) + acc
+      if (cnt <= 0) v
+      else loop(cnt - 1, v)
+    }
+
+    bh.consume(loop(100, 0))
+  }
+
+  @Benchmark
+  def randomAccessTreeList(bh: Blackhole): Unit = {
+
+    val rand = new java.util.Random(42)
+    @tailrec
+    def loop(cnt: Int, acc: Int): Int = {
+      val v = treeList.getUnsafe((rand.nextInt() & Int.MaxValue) % n) + acc
+      if (cnt <= 0) v
+      else loop(cnt - 1, v)
+    }
+
+    bh.consume(loop(100, 0))
+  }
+}

--- a/tests/src/test/scala/cats/collections/TreeListSpec.scala
+++ b/tests/src/test/scala/cats/collections/TreeListSpec.scala
@@ -6,8 +6,6 @@ import cats.laws.discipline._
 import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 
-import cats.implicits._
-
 import cats.collections.arbitrary.ArbitraryTreeList._
 
 class TreeListSpec extends CatsSuite {
@@ -104,10 +102,16 @@ class TreeListSpec extends CatsSuite {
 
   test("pattern matching works")(forAll { (xs: TreeList[Int]) =>
     xs match {
-      case TreeList.Empty => assert(xs.isEmpty)
+      case TreeList.Empty =>
+        assert(xs.uncons == None)
+        assert(xs.isEmpty)
+        assert(xs.headOption == None)
+        assert(xs.tailOption == None)
       case TreeList.NonEmpty(head, tail) =>
         assert(xs.nonEmpty)
         assert(Some((head, tail)) == xs.uncons)
+        assert(Some(head) == xs.headOption)
+        assert(Some(tail) == xs.tailOption)
     }
   })
 
@@ -170,10 +174,17 @@ class TreeListSpec extends CatsSuite {
   test("TreeList.get works")(forAll { (xs: TreeList[Int]) =>
     assert(xs.get(-1L) == None)
     assert(xs.get(xs.size) == None)
+    assertThrows[NoSuchElementException] {
+      xs.getUnsafe(-1L)
+    }
+    assertThrows[NoSuchElementException] {
+      xs.getUnsafe(xs.size)
+    }
 
     val list = xs.toList
     (0L until xs.size).foreach { idx =>
       assert(xs.get(idx) == Some(list(idx.toInt)))
+      assert(xs.getUnsafe(idx) == list(idx.toInt))
     }
   })
 


### PR DESCRIPTION
I added some basic benchmarks on the doing uncons, which would be a common way to treat TreeList like a list, and also randomly accessing.

I compare to List and Vector. You see that TreeList is in-between: better than Vector at uncons style loops, but worse that List, but for indexing better than List, but worse than Vector.

I optimized things a bit to get the numbers better. There may be some more optimizations to be done.

We can also add more benchmarks to optimize some other methods.

Here is what I get on my machine with `bench/jmh:run -i 10 -wi 3 -f1 -t1 .*TreeList.*`
```
[info] Benchmark                             (n)   Mode  Cnt        Score        Error  Units
[info] TreeListBench.randomAccessList        100  thrpt   10   102722.970 ±   3406.116  ops/s
[info] TreeListBench.randomAccessList       1000  thrpt   10     8078.933 ±    527.967  ops/s
[info] TreeListBench.randomAccessList      10000  thrpt   10      801.646 ±     27.491  ops/s
[info] TreeListBench.randomAccessTreeList    100  thrpt   10   307635.372 ±   8541.581  ops/s
[info] TreeListBench.randomAccessTreeList   1000  thrpt   10   183573.419 ±   4741.105  ops/s
[info] TreeListBench.randomAccessTreeList  10000  thrpt   10   108438.484 ±   3007.891  ops/s
[info] TreeListBench.randomAccessVector      100  thrpt   10   589303.317 ±  19169.774  ops/s
[info] TreeListBench.randomAccessVector     1000  thrpt   10   576697.636 ±  17902.104  ops/s
[info] TreeListBench.randomAccessVector    10000  thrpt   10   503391.560 ±  16328.585  ops/s
[info] TreeListBench.sumList                 100  thrpt   10  3616081.912 ± 144750.913  ops/s
[info] TreeListBench.sumList                1000  thrpt   10   343178.933 ±  10244.320  ops/s
[info] TreeListBench.sumList               10000  thrpt   10    32504.710 ±    797.045  ops/s
[info] TreeListBench.sumTreeList             100  thrpt   10   541582.038 ±  20836.575  ops/s
[info] TreeListBench.sumTreeList            1000  thrpt   10    52578.604 ±   1811.349  ops/s
[info] TreeListBench.sumTreeList           10000  thrpt   10     5144.769 ±    156.547  ops/s
[info] TreeListBench.sumVector               100  thrpt   10   151562.505 ±   2848.411  ops/s
[info] TreeListBench.sumVector              1000  thrpt   10    10138.505 ±    171.363  ops/s
[info] TreeListBench.sumVector             10000  thrpt   10      762.404 ±     26.735  ops/s
```