### PR TITLE
improve Heap (fix #158), increase test coverage

### DIFF
--- a/core/src/main/scala/cats/collections/Heap.scala
+++ b/core/src/main/scala/cats/collections/Heap.scala
@@ -64,21 +64,12 @@ sealed abstract class Heap[A] {
     else
       bubbleUp(min, left.add(x), right)
 
-  /**
-   * Build a heap using a list.
-   * Order O(n)
-   */
-  def heapify(a: List[A])(implicit order: Order[A]): Heap[A] = {
-    def loop(i: Int, xs: scala.List[A]): Heap[A] =
-      if (i < xs.length) {
-        bubbleDown(xs(i), loop(2 * i + 1, xs), loop(2 * i + 2, xs))
-      }
-      else {
-        Leaf()
-      }
 
-    loop(0, a)
-  }
+  /**
+   * Avoid this, it should really have been on the companion
+   */
+  def heapify(a: List[A])(implicit order: Order[A]): Heap[A] =
+    Heap.heapify(a)
 
   /**
    * Remove the min element from the heap (the root).
@@ -117,6 +108,33 @@ object Heap {
 
   def apply[A](x: A, l: Heap[A], r: Heap[A]): Heap[A] =
     Branch(x, l, r, l.size + r.size + 1, scala.math.max(l.height, r.height) + 1)
+
+  /**
+   * alias for heapify
+   */
+  def fromList[A](as: List[A])(implicit order: Order[A]): Heap[A] =
+    heapify(as)
+
+  /**
+   * Build a heap using a list.
+   * Order O(n)
+   */
+  def heapify[A](a: List[A])(implicit order: Order[A]): Heap[A] = {
+    val ary = (a: List[Any]).toArray
+    def loop(i: Int): Heap[A] =
+      if (i < ary.length) {
+        // we only insert A values, but we don't have a ClassTag
+        // so we can't create an array of type A.
+        // But since A was already boxed, and needs to be boxed in Heap
+        // this shouldn't cause a performance problem
+        bubbleDown(ary(i).asInstanceOf[A], loop((i << 1) + 1), loop((i + 1) << 1))
+      }
+      else {
+        Leaf()
+      }
+
+    loop(0)
+  }
 
   private[collections] case class Branch[A](min: A, left: Heap[A], right: Heap[A], size: Int, height: Int) extends Heap[A] {
     override def isEmpty: Boolean = false

--- a/core/src/main/scala/cats/collections/Heap.scala
+++ b/core/src/main/scala/cats/collections/Heap.scala
@@ -249,9 +249,16 @@ object Heap {
   }
 
   implicit def toShowable[A](implicit s: Show[A], order: Order[A]): Show[Heap[A]] = new Show[Heap[A]] {
-    override def show(f: Heap[A]): String = f.toList match {
-      case Nil => "[]"
-      case h :: t => t.foldLeft("[" + s.show(h))((acc, r) => acc + ", " + s.show(r)) + "]"
+    override def show(f: Heap[A]): String = {
+      val sb = new java.lang.StringBuilder
+      sb.append("Heap(")
+      f.foldLeft(false) { (notFirst, a) =>
+        if (notFirst) sb.append(", ")
+        sb.append(s.show(a))
+        true
+      }
+      sb.append(")")
+      sb.toString
     }
   }
 }

--- a/core/src/main/scala/cats/collections/Heap.scala
+++ b/core/src/main/scala/cats/collections/Heap.scala
@@ -55,9 +55,9 @@ sealed abstract class Heap[A] {
   def add(x: A)(implicit order: Order[A]): Heap[A] =
     if (isEmpty)
       Heap(x, Leaf(), Leaf())
-    else if (left.size < (1 >> right.height) - 1)
+    else if (left.size < (1 << left.height) - 1)
       bubbleUp(min, left.add(x), right)
-    else if (right.size < (1 >> right.height) - 1)
+    else if (right.size < (1 << right.height) - 1)
       bubbleUp(min, left, right.add(x))
     else if (right.height < left.height)
       bubbleUp(min, left, right.add(x))
@@ -196,10 +196,10 @@ object Heap {
     if (l.isEmpty && r.isEmpty) {
       Leaf()
     }
-    else if (l.size < (1 >> l.height) - 1) {
+    else if (l.size < (1 << l.height) - 1) {
       floatLeft(l.min, mergeChildren(l.left, l.right), r)
     }
-    else if (r.size < (1 >> r.height) - 1) {
+    else if (r.size < (1 << r.height) - 1) {
       floatRight(r.min, l, mergeChildren(r.left, r.right))
     }
     else if (r.height < l.height) {

--- a/core/src/main/scala/cats/collections/Heap.scala
+++ b/core/src/main/scala/cats/collections/Heap.scala
@@ -83,9 +83,15 @@ sealed abstract class Heap[A] {
   /**
    * Returns a sorted list of the elements within the heap.
    */
-  def toList(implicit order: Order[A]): List[A] = this match {
-    case Leaf() => Nil
-    case Branch(m, _, _, _, _) => m :: remove.toList
+  def toList(implicit order: Order[A]): List[A] = {
+    @annotation.tailrec
+    def loop(h: Heap[A], acc: List[A]): List[A] =
+      h match {
+        case Leaf() => acc.reverse
+        case Branch(m, _, _, _, _) => loop(h.remove, m :: acc)
+      }
+
+    loop(this, Nil)
   }
 
   /**

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -10,7 +10,7 @@ import org.scalacheck.{Arbitrary, Gen}
  */
 class HeapSpec extends CatsSuite {
   implicit val propConfig =
-    PropertyCheckConfig(minSuccessful = 200)
+    PropertyCheckConfig(minSuccessful = 1000)
 
   test("sorted")(
     forAll { (set: Set[Int]) =>
@@ -62,7 +62,7 @@ class HeapSpec extends CatsSuite {
 
   implicit def arbHeap[A: Arbitrary: Order]: Arbitrary[Heap[A]] =
     Arbitrary {
-      Gen.choose(0, 10000).flatMap(heapGen[A](_, Arbitrary.arbitrary[A]))
+      Gen.sized(heapGen[A](_, Arbitrary.arbitrary[A]))
     }
 
   test("adding increases size") {

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -26,7 +26,7 @@ class HeapSpec extends CatsSuite {
   test("heapify is sorted") {
     forAll { (set: Set[Int]) =>
       val setList = set.toList
-      val heap = Heap.empty[Int].heapify(setList)
+      val heap = Heap.heapify(setList)
 
       assert(heap.toList == setList.sorted)
     }
@@ -81,9 +81,11 @@ class HeapSpec extends CatsSuite {
     assert(Heap.empty[Int].remove == Heap.empty[Int])
   }
 
-  test("size is consistent with isEmpty") {
+  test("size is consistent with isEmpty/nonEmpty") {
     forAll { (heap: Heap[Int]) =>
       assert(heap.isEmpty == (heap.size == 0))
+      assert(heap.nonEmpty == (heap.size > 0))
+      assert(heap.isEmpty == (!heap.nonEmpty))
     }
   }
 

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -76,7 +76,7 @@ class HeapSpec extends CatsSuite {
 
   test("height is O(log N) for all heaps") {
     forAll { (heap: Heap[Int]) =>
-      val bound = 2.0 * (math.log(heap.size.toDouble) / math.log(2.0) + 1)
+      val bound = 1.0 * (math.log(heap.size.toDouble) / math.log(2.0) + 1)
       assert(heap.isEmpty || heap.height.toDouble <= bound)
     }
   }

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -1,7 +1,7 @@
 package cats.collections
 package tests
 
-import cats.Order
+import cats.{Order, Show}
 import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -107,6 +107,12 @@ class HeapSpec extends CatsSuite {
   test("Heap.foldLeft is consistent with toList.foldLeft") {
     forAll { (heap: Heap[Int], init: Long, fn: (Long, Int) => Long) =>
       assert(heap.foldLeft(init)(fn) == heap.toList.foldLeft(init)(fn))
+    }
+  }
+
+  test("Show[Heap[Int]] works like toList.mkString") {
+    forAll { (heap: Heap[Int]) =>
+      assert(Show[Heap[Int]].show(heap) == heap.toList.mkString("Heap(", ", ", ")"))
     }
   }
 }

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -1,16 +1,16 @@
 package cats.collections
 package tests
 
+import cats.Order
 import cats.tests.CatsSuite
+import org.scalacheck.{Arbitrary, Gen}
 
 /**
  * Created by nperez on 3/28/16.
  */
 class HeapSpec extends CatsSuite {
   test("sorted")(
-    forAll { (xs: scala.List[Int]) =>
-
-      val set = xs.toSet
+    forAll { (set: Set[Int]) =>
 
       val heap = set.foldLeft(Heap.empty[Int])((h, i) => h.add(i))
 
@@ -19,4 +19,66 @@ class HeapSpec extends CatsSuite {
       heap.toList should be(exp.sorted)
 
     })
+
+  test("heapify is sorted") {
+    forAll { (set: Set[Int]) =>
+      val setList = set.toList
+      val heap = Heap.empty[Int].heapify(setList)
+
+      assert(heap.toList == setList.sorted)
+    }
+  }
+
+  def heapGen[A: Order](size: Int, agen: Gen[A]): Gen[Heap[A]] = {
+    val listA = Gen.listOfN(size, agen)
+    val addOnly = listA.map(_.foldLeft(Heap.empty[A])(_.add(_)))
+    val heapify = listA.map(Heap.fromList(_))
+    val addMoreAndRemove: Gen[Heap[A]] =
+      for {
+        extraSize <- Gen.choose(1, size + 1)
+        withExtra <- Gen.lzy(heapGen[A](size + extraSize, agen))
+      } yield (0 until extraSize).foldLeft(withExtra) { (h, _) => h.remove }
+
+    Gen.frequency((2, addOnly), (2, heapify), (1, addMoreAndRemove))
+  }
+
+  implicit def arbHeap[A: Arbitrary: Order]: Arbitrary[Heap[A]] =
+    Arbitrary {
+      Gen.choose(0, 10000).flatMap(heapGen[A](_, Arbitrary.arbitrary[A]))
+    }
+
+  test("adding increases size") {
+    forAll { (heap: Heap[Int], x: Int) =>
+      val heap1 = heap + x
+      assert(heap1.size == (heap.size + 1))
+    }
+  }
+
+  test("remove decreases size") {
+    forAll { (heap: Heap[Int]) =>
+      val heap1 = heap.remove
+      assert((heap1.size == (heap.size - 1)) || (heap1.isEmpty && heap.isEmpty))
+    }
+  }
+
+  test("size is consistent with isEmpty") {
+    forAll { (heap: Heap[Int]) =>
+      assert(heap.isEmpty == (heap.size == 0))
+    }
+  }
+
+  test("height is O(log N) for all heaps") {
+    forAll { (heap: Heap[Int]) =>
+      val bound = 2.0 * (math.log(heap.size.toDouble) / math.log(2.0) + 1)
+      assert(heap.isEmpty || heap.height.toDouble <= bound)
+    }
+  }
+
+  test("heapify is the same as adding") {
+    forAll { (init: List[Int]) =>
+      val heap1 = Heap.fromList(init)
+      val heap2 = init.foldLeft(Heap.empty[Int])(_.add(_))
+      assert(heap1.toList == heap2.toList)
+    }
+  }
 }

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -37,7 +37,7 @@ class HeapSpec extends CatsSuite {
         case h :: tail => tail.foldLeft(Heap(h))(_.add(_))
       }
     val addOnly = listA.map(_.foldLeft(Heap.empty[A])(_.add(_)))
-    val heapify = listA.map(Heap.fromList(_))
+    val heapify = listA.map(Heap.fromIterable(_))
     val addMoreAndRemove: Gen[Heap[A]] =
       for {
         extraSize <- Gen.choose(1, size + 1)
@@ -83,7 +83,7 @@ class HeapSpec extends CatsSuite {
 
   test("heapify is the same as adding") {
     forAll { (init: List[Int]) =>
-      val heap1 = Heap.fromList(init)
+      val heap1 = Heap.fromIterable(init)
       val heap2 = init.foldLeft(Heap.empty[Int])(_.add(_))
       assert(heap1.toList == heap2.toList)
     }
@@ -102,5 +102,11 @@ class HeapSpec extends CatsSuite {
     }
 
     assert(Heap.empty[Int].getMin.isEmpty)
+  }
+
+  test("Heap.foldLeft is consistent with toList.foldLeft") {
+    forAll { (heap: Heap[Int], init: Long, fn: (Long, Int) => Long) =>
+      assert(heap.foldLeft(init)(fn) == heap.toList.foldLeft(init)(fn))
+    }
   }
 }

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -31,6 +31,11 @@ class HeapSpec extends CatsSuite {
 
   def heapGen[A: Order](size: Int, agen: Gen[A]): Gen[Heap[A]] = {
     val listA = Gen.listOfN(size, agen)
+    val startWith1 =
+      listA.map {
+        case Nil => Heap.empty[A]
+        case h :: tail => tail.foldLeft(Heap(h))(_.add(_))
+      }
     val addOnly = listA.map(_.foldLeft(Heap.empty[A])(_.add(_)))
     val heapify = listA.map(Heap.fromList(_))
     val addMoreAndRemove: Gen[Heap[A]] =
@@ -39,7 +44,7 @@ class HeapSpec extends CatsSuite {
         withExtra <- Gen.lzy(heapGen[A](size + extraSize, agen))
       } yield (0 until extraSize).foldLeft(withExtra) { (h, _) => h.remove }
 
-    Gen.frequency((2, addOnly), (2, heapify), (1, addMoreAndRemove))
+    Gen.frequency((1, addOnly), (1, startWith1), (2, heapify), (1, addMoreAndRemove))
   }
 
   implicit def arbHeap[A: Arbitrary: Order]: Arbitrary[Heap[A]] =
@@ -59,6 +64,8 @@ class HeapSpec extends CatsSuite {
       val heap1 = heap.remove
       assert((heap1.size == (heap.size - 1)) || (heap1.isEmpty && heap.isEmpty))
     }
+
+    assert(Heap.empty[Int].remove == Heap.empty[Int])
   }
 
   test("size is consistent with isEmpty") {
@@ -80,5 +87,20 @@ class HeapSpec extends CatsSuite {
       val heap2 = init.foldLeft(Heap.empty[Int])(_.add(_))
       assert(heap1.toList == heap2.toList)
     }
+  }
+
+  test("Heap.getMin is the real minimum") {
+    forAll { (heap: Heap[Int]) =>
+      heap.getMin match {
+        case None => assert(heap.isEmpty)
+        case Some(min) =>
+          val heap1 = heap.remove
+          assert(heap1.isEmpty || {
+            min <= heap1.toList.min
+          })
+      }
+    }
+
+    assert(Heap.empty[Int].getMin.isEmpty)
   }
 }

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -9,7 +9,7 @@ import org.scalacheck.{Arbitrary, Gen}
  * Created by nperez on 3/28/16.
  */
 class HeapSpec extends CatsSuite {
-  implicit override val generatorDrivenConfig =
+  implicit val propConfig =
     PropertyCheckConfig(minSuccessful = 200)
 
   test("sorted")(
@@ -89,7 +89,7 @@ class HeapSpec extends CatsSuite {
 
   test("height is O(log N) for all heaps") {
     forAll { (heap: Heap[Int]) =>
-      val bound = 1.0 * (math.log(heap.size.toDouble) / math.log(2.0) + 1)
+      val bound = math.log(heap.size.toDouble) / math.log(2.0) + 1.0
       assert(heap.isEmpty || heap.height.toDouble <= bound)
     }
   }


### PR DESCRIPTION
This does three things:

1. increase test coverage (I want to go for 100% so I will probably add a few more commits after codecov runs).
2. fix #158 by using an Array rather than indexing into a List
3. notice that heapify totally ignores the current `Heap` so it should be on the companion. If we can break compatibility, we should remove the method.

I'm not super excited about the Heap code, if we can break compatibility, I'd like to make a few other changes. Please advise on that and I will follow up in a second PR.