### PR TITLE
Add Heap#addAll and stronger invariant test

### DIFF
--- a/core/src/main/scala/cats/collections/Heap.scala
+++ b/core/src/main/scala/cats/collections/Heap.scala
@@ -70,6 +70,18 @@ sealed abstract class Heap[A] {
     }
 
   /**
+   * Add a collection of items in. This is O(N log N) if as is size N
+   */
+  def addAll(as: Iterable[A])(implicit order: Order[A]): Heap[A] = {
+    val ait = as.iterator
+    var heap = this
+    while(ait.hasNext) {
+      heap = heap + ait.next()
+    }
+    heap
+  }
+
+  /**
    * Check to see if a predicate is ever true
    */
   def exists(fn: A => Boolean): Boolean =
@@ -161,6 +173,11 @@ sealed abstract class Heap[A] {
    * Alias for add
    */
   def +(x: A)(implicit order: Order[A]): Heap[A] = add(x)
+
+  /**
+   * Alias for addAll
+   */
+  def ++(as: Iterable[A])(implicit order: Order[A]): Heap[A] = addAll(as)
 
   /**
    * Alias for remove
@@ -330,15 +347,19 @@ object Heap {
   private[collections] class HeapOrder[A](implicit ordA: Order[A]) extends Order[Heap[A]] {
     @tailrec
     final def compare(left: Heap[A], right: Heap[A]): Int =
-      (left.getMin, right.getMin) match {
-        case (None, None) => 0
-        case (None, Some(_)) => -1
-        case (Some(_), None) => 1
-        case (Some(l), Some(r)) =>
-          val c = ordA.compare(l, r)
-          if (c != 0) c
-          else compare(left.remove, right.remove)
-    }
+      if (left.isEmpty) {
+        if (right.isEmpty) 0
+        else -1
+      }
+      else if (right.isEmpty) 1
+      else {
+        // both are not empty
+        val lb = left.asInstanceOf[Branch[A]]
+        val rb = right.asInstanceOf[Branch[A]]
+        val c = ordA.compare(lb.min, rb.min)
+        if (c != 0) c
+        else compare(left.remove, right.remove)
+      }
   }
   /**
    * This is the same order as you would get by doing `.toList` and ordering by that

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -39,7 +39,12 @@ class HeapSpec extends CatsSuite {
       }
       else Gen.const(Heap.empty[A])
 
-    Gen.frequency((2, addOnly), (3, startWith1), (5, heapify), (1, addMoreAndRemove), (1, smallerAdd))
+    Gen.frequency(
+      (2, addOnly),
+      (3, startWith1),
+      (5, heapify),
+      (1, addMoreAndRemove),
+      (1, smallerAdd))
   }
 
   implicit def arbHeap[A: Arbitrary: Order]: Arbitrary[Heap[A]] =
@@ -82,6 +87,30 @@ class HeapSpec extends CatsSuite {
     }
   }
 
+  test("add is the same as +") {
+    forAll { (heap: Heap[Int], x: Int) =>
+      val heap1 = heap + x
+      val heap2 = heap.add(x)
+      assert(Order[Heap[Int]].eqv(heap1, heap2))
+    }
+  }
+
+  test("addAll is the same as ++") {
+    forAll { (heap: Heap[Int], x: List[Int]) =>
+      val heap1 = heap ++ x
+      val heap2 = heap.addAll(x)
+      assert(Order[Heap[Int]].eqv(heap1, heap2))
+    }
+  }
+
+  test("addAll is the same as folding with add") {
+    forAll { (heap: Heap[Int], x: List[Int]) =>
+      val heap1 = heap.addAll(x)
+      val heap2 = x.foldLeft(heap)(_.add(_))
+      assert(Order[Heap[Int]].eqv(heap1, heap2))
+    }
+  }
+
   test("remove decreases size") {
     forAll { (heap: Heap[Int]) =>
       val heap1 = heap.remove
@@ -99,7 +128,7 @@ class HeapSpec extends CatsSuite {
     }
   }
 
-  test("height is O(log N) for all heaps") {
+  test("height is <= log_2 N + 1 for all heaps") {
     forAll { (heap: Heap[Int]) =>
       val bound = math.log(heap.size.toDouble) / math.log(2.0) + 1.0
       assert(heap.isEmpty || heap.height.toDouble <= bound)
@@ -196,6 +225,29 @@ class HeapSpec extends CatsSuite {
       assert(ord.lt(Heap.empty, Heap.empty + item))
       assert(ord.gteqv(heap, Heap.empty))
       assert(ord.gt(Heap.empty + item, Heap.empty))
+    }
+  }
+
+  test("Heap property is always maintained") {
+    def law[A](h: Heap[A], outer: Heap[A])(implicit ord: Order[A]): Unit =
+      h match {
+        case Heap.Leaf() => ()
+        case Heap.Branch(min, left, right) =>
+          lazy val heapStr = if (outer != h) s"in $outer, subheap $h" else h.toString
+          left.getMin.foreach { m => assert(ord.gteqv(m, min), s"$heapStr violates heap order property on left") }
+          right.getMin.foreach { m => assert(ord.gteqv(m, min), s"$heapStr violates heap order property on right") }
+          // we expect fully balanced heaps, but we put the size on the left first:
+          assert(left.size >= right.size,
+            s"$heapStr has left size = ${left.size} vs right size = ${right.size}")
+          assert((left.height == right.height) || (left.height == right.height + 1),
+            s"$heapStr has unbalanced height: ${left.height} vs ${right.height}")
+
+          law(left, outer)
+          law(right, outer)
+      }
+
+    forAll { (h: Heap[Int]) =>
+      law(h, h)
     }
   }
 }


### PR DESCRIPTION
I added a stronger test of the fully balanced tree invariant in Heap.

I added addAll and a synonym ++

finally, I tried to implement merge, but I couldn't find anything that kept the strong invariants and was any better than O(N log N) on the smaller heap, which is trivial to implement but I don't think useful since it is the same as `left ++ (right.toList)` in complexity.

I think it may be impossible to make merge efficient while also maintaining a completely balanced tree without any slack. It might be possible to show worst case is O(N log N) by constructing some pathological examples of pairs of highly unbalanced heaps.

cc @larsrh 