### PR TITLE
Add PairingHeap for a fast Heap CommutativeMonoid

### DIFF
--- a/core/src/main/scala/cats/collections/Heap.scala
+++ b/core/src/main/scala/cats/collections/Heap.scala
@@ -172,6 +172,17 @@ sealed abstract class Heap[A] {
    */
   def --(implicit order: Order[A]): Heap[A] = remove
 
+  /**
+   * convert to a PairingHeap which can do fast merges,
+   * this is an O(N) operation
+   */
+  def toPairingHeap: PairingHeap[A] =
+    if (isEmpty) PairingHeap.empty
+    else {
+      val thisBranch = this.asInstanceOf[Branch[A]]
+      import thisBranch.{min, left, right}
+      PairingHeap.Tree(min, left.toPairingHeap :: right.toPairingHeap :: Nil)
+    }
 }
 
 object Heap {

--- a/core/src/main/scala/cats/collections/Heap.scala
+++ b/core/src/main/scala/cats/collections/Heap.scala
@@ -21,9 +21,14 @@ sealed abstract class Heap[A] {
   import Heap._
 
   /**
-   * Returns min value on the heap.
+   * Returns min value on the heap, if it exists
    */
-  def getMin: Option[A]
+  final def getMin: Option[A] = minimumOption
+
+  /**
+   * Returns min value on the heap, if it exists
+   */
+  def minimumOption: Option[A]
 
   // this is size < 2^height - 1
   // this is always false for empty, and sometimes false for non-empty
@@ -187,6 +192,27 @@ object Heap {
     heapify(as)
 
   /**
+   * this is useful for finding the k maximum values in O(N) times for N items
+   * same as as.toList.sorted.reverse.take(count), but O(N log(count)) vs O(N log N)
+   * for a full sort. When N is very large, this can be a very large savings
+   */
+  def takeLargest[A](as: Iterable[A], count: Int)(implicit order: Order[A]): Heap[A] =
+    if (count <= 0) empty
+    else {
+      var heap = empty[A]
+      val iter = as.iterator
+      while (iter.hasNext) {
+        val a = iter.next()
+        heap =
+          if (heap.size < count) heap + a
+          else if (order.lt(heap.asInstanceOf[Branch[A]].min, a)) heap.remove + a
+          else heap
+      }
+
+      heap
+    }
+
+  /**
    * Build a heap using an Iterable
    * Order O(n)
    */
@@ -214,7 +240,7 @@ object Heap {
 
     override def isEmpty: Boolean = false
 
-    override def getMin: Option[A] = Some(min)
+    override def minimumOption: Option[A] = Some(min)
 
     override def unbalanced: Boolean = size < (1L << height) - 1L
   }
@@ -233,7 +259,7 @@ object Heap {
 
     override def isEmpty: Boolean = true
 
-    override def getMin: Option[Nothing] = None
+    override def minimumOption: Option[Nothing] = None
   }
 
   private[collections] def bubbleUp[A](x: A, l: Heap[A], r: Heap[A])(implicit order: Order[A]): Heap[A] = (l, r) match {

--- a/core/src/main/scala/cats/collections/PairingHeap.scala
+++ b/core/src/main/scala/cats/collections/PairingHeap.scala
@@ -1,0 +1,349 @@
+package cats.collections
+
+import cats.{Order, UnorderedFoldable, Show}
+import cats.kernel.CommutativeMonoid
+import scala.annotation.tailrec
+
+/**
+ * A PairingHeap is a heap with excellent empirical performance.
+ *
+ * See:
+ * https://en.wikipedia.org/wiki/Pairing_heap
+ * in particular:
+ * https://en.wikipedia.org/wiki/Pairing_heap#Summary_of_running_times
+ *
+ * Additionally, it supports an efficient O(1) combine operation
+ */
+sealed abstract class PairingHeap[A] {
+
+  import PairingHeap._
+
+  /**
+   * insert an item into the heap
+   * O(1)
+   */
+  def add(x: A)(implicit order: Order[A]): PairingHeap[A] =
+    if (this.isEmpty) apply(x)
+    else {
+      val thisTree = this.asInstanceOf[Tree[A]]
+      if (order.lteqv(x, thisTree.min)) Tree(x, this :: Nil)
+      else Tree(thisTree.min, Tree(x, Nil) :: thisTree.subtrees)
+    }
+
+  /**
+   * Returns min value on the heap, if it exists
+   *
+   * O(1)
+   */
+  def minimumOption: Option[A]
+
+  /**
+   * Returns the size of the heap.
+   * O(1)
+   */
+  def size: Long
+
+  /**
+   * Verifies if the heap is empty.
+   * O(1)
+   */
+  def isEmpty: Boolean
+
+  /**
+   * Return true if this is not empty
+   * O(1)
+   */
+  def nonEmpty: Boolean = !isEmpty
+
+  /**
+   * Returns a sorted list of the elements within the heap.
+   * O(N log N)
+   */
+  def toList(implicit order: Order[A]): List[A] = {
+    @tailrec
+    def loop(h: PairingHeap[A], acc: List[A]): List[A] =
+      h match {
+        case Tree(m, _) => loop(h.remove, m :: acc)
+        case Leaf()          => acc.reverse
+      }
+
+    loop(this, Nil)
+  }
+
+  /**
+   * Merge two heaps, this is O(1) work
+   */
+  def combine(that: PairingHeap[A])(implicit order: Order[A]): PairingHeap[A]
+
+  /**
+   * Check to see if a predicate is ever true
+   * worst case O(N) but stops at the first true
+   */
+  def exists(fn: A => Boolean): Boolean
+
+  /**
+   * Check to see if a predicate is always true
+   * worst case O(N) but stops at the first false
+   */
+  def forall(fn: A => Boolean): Boolean
+
+  /**
+   * Aggregate with a commutative monoid, since the Heap is not totally
+   * ordered
+   */
+  def unorderedFoldMap[B](fn: A => B)(implicit m: CommutativeMonoid[B]): B =
+    if (isEmpty) m.empty
+    else {
+      val thisTree = this.asInstanceOf[Tree[A]]
+      m.combine(fn(thisTree.min), m.combineAll(thisTree.subtrees.map(_.unorderedFoldMap(fn))))
+    }
+
+  /**
+   * Similar to unorderedFoldMap without a transformation
+   */
+  def unorderedFold(implicit m: CommutativeMonoid[A]): A =
+    if (isEmpty) m.empty
+    else {
+      val thisTree = this.asInstanceOf[Tree[A]]
+      m.combine(thisTree.min, m.combineAll(thisTree.subtrees.map(_.unorderedFold)))
+    }
+
+  /**
+   * do a foldLeft in the same order as toList.
+   * requires an Order[A], which prevents us from making a Foldable[PairingHeap] instance.
+   *
+   * prefer unorderedFoldMap if you can express your operation as a commutative monoid
+   * since it is O(N) vs O(N log N) for this method
+   */
+  def foldLeft[B](init: B)(fn: (B, A) => B)(implicit order: Order[A]): B = {
+    @tailrec
+    def loop(h: PairingHeap[A], acc: B): B =
+      h match {
+        case Tree(m, _) => loop(h.remove, fn(acc, m))
+        case Leaf()          => acc
+      }
+
+    loop(this, init)
+  }
+
+  /**
+   * if not empty, remove the min, else return empty
+   * this is thought to be O(log N) (but not proven to be so)
+   */
+  def remove(implicit order: Order[A]): PairingHeap[A] =
+    if (isEmpty) this
+    else {
+      val thisTree = this.asInstanceOf[Tree[A]]
+      combineAll(thisTree.subtrees)
+    }
+
+  /**
+   * Alias for add
+   */
+  def +(x: A)(implicit order: Order[A]): PairingHeap[A] = add(x)
+}
+
+object PairingHeap {
+
+  def empty[A]: PairingHeap[A] = Leaf()
+
+  def apply[A](x: A): PairingHeap[A] = Tree(x, Nil)
+
+  /**
+   * This is thought to be O(log N) where N is the size of the final heap
+   */
+  def combineAll[A: Order](it: Iterable[PairingHeap[A]]): PairingHeap[A] =
+    combineAllIter(it.iterator, Nil)
+
+  @tailrec
+  private def combineLoop[A: Order](ts: List[PairingHeap[A]], acc: PairingHeap[A]): PairingHeap[A] =
+    ts match{
+      case Nil => acc
+      case h :: tail => combineLoop(tail, h.combine(acc))
+    }
+
+  @tailrec
+  private def combineAllIter[A: Order](iter: Iterator[PairingHeap[A]], tail: List[PairingHeap[A]]): PairingHeap[A] =
+    if (iter.isEmpty) {
+      combineLoop(tail, empty[A])
+    }
+    else {
+      val p0 = iter.next()
+      if (iter.isEmpty) combineLoop(tail, p0)
+      else {
+        val p1 = iter.next()
+        combineAllIter(iter, p1 :: p0 :: tail)
+      }
+    }
+
+  // this is a combineall that only counts the number of combines is needs
+  // to do for testing
+  // this should be kept in sync with combineAllIter
+  private[collections] def combineAllIterCount[A: Order](iter: Iterator[PairingHeap[A]], cnt: Int): Int =
+    if (iter.isEmpty) cnt
+    else {
+      iter.next()
+      if (iter.isEmpty) cnt + 1
+      else {
+        iter.next()
+        combineAllIterCount(iter, cnt + 2)
+      }
+    }
+
+  /**
+   * build a heap from a list of items, O(N)
+   */
+  def fromIterable[A](as: Iterable[A])(implicit order: Order[A]): PairingHeap[A] = {
+    val iter = as.iterator
+    var heap = empty[A]
+    while(iter.hasNext) {
+      heap = heap + iter.next()
+    }
+    heap
+  }
+
+  /**
+   * this is useful for finding the k maximum values in O(N) times for N items
+   * same as as.toList.sorted.reverse.take(count), but O(N log(count)) vs O(N log N)
+   * for a full sort. When N is very large, this can be a very large savings
+   */
+  def takeLargest[A](as: Iterable[A], count: Int)(implicit order: Order[A]): PairingHeap[A] =
+    if (count <= 0) empty
+    else {
+      var heap = empty[A]
+      val iter = as.iterator
+      while (iter.hasNext) {
+        val a = iter.next()
+        heap =
+          if (heap.size < count) heap + a
+          else if (order.lt(heap.asInstanceOf[Tree[A]].min, a)) heap.remove + a
+          else heap
+      }
+
+      heap
+    }
+
+  private case class Tree[A](min: A, subtrees: List[PairingHeap[A]]) extends PairingHeap[A] {
+    override val size = {
+      @tailrec
+      def loop(ts: List[PairingHeap[A]], acc: Long): Long =
+        ts match {
+          case Nil => acc
+          case h :: tail => loop(tail, acc + h.size)
+        }
+      loop(subtrees, 1L)
+    }
+
+    override def isEmpty: Boolean = false
+
+    override def minimumOption: Option[A] = Some(min)
+
+    override def exists(fn: A => Boolean): Boolean =
+      fn(min) || {
+        @tailrec
+        def loop(hs: List[PairingHeap[A]]): Boolean =
+          hs match {
+            case h :: tail => h.exists(fn) || loop(tail)
+            case Nil => false
+          }
+        loop(subtrees)
+      }
+
+    override def forall(fn: A => Boolean): Boolean =
+      fn(min) && {
+        @tailrec
+        def loop(hs: List[PairingHeap[A]]): Boolean =
+          hs match {
+            case h :: tail => h.forall(fn) && loop(tail)
+            case Nil => true
+          }
+        loop(subtrees)
+      }
+
+    override def combine(that: PairingHeap[A])(implicit order: Order[A]): PairingHeap[A] =
+      if (that.isEmpty) this
+      else {
+        val thatTree = that.asInstanceOf[Tree[A]]
+        if (order.lt(min, thatTree.min)) Tree(min, that :: subtrees)
+        else Tree(thatTree.min, this :: thatTree.subtrees)
+      }
+  }
+
+  private case object Leaf extends PairingHeap[Nothing] {
+    def apply[A](): PairingHeap[A] = this.asInstanceOf[PairingHeap[A]]
+
+    def unapply[A](heap: PairingHeap[A]): Boolean = heap.isEmpty
+
+    override def size: Long = 0L
+
+    override def isEmpty: Boolean = true
+
+    override def minimumOption: Option[Nothing] = None
+
+    override def exists(fn: Nothing => Boolean): Boolean = false
+
+    override def forall(fn: Nothing => Boolean): Boolean = true
+
+    override def combine(that: PairingHeap[Nothing])(implicit order: Order[Nothing]): PairingHeap[Nothing] = that
+  }
+
+  implicit def toShowable[A](implicit s: Show[A], order: Order[A]): Show[PairingHeap[A]] = new Show[PairingHeap[A]] {
+    override def show(f: PairingHeap[A]): String = {
+      val sb = new java.lang.StringBuilder
+      sb.append("PairingHeap(")
+      f.foldLeft(false) { (notFirst, a) =>
+        if (notFirst) sb.append(", ")
+        sb.append(s.show(a))
+        true
+      }
+      sb.append(")")
+      sb.toString
+    }
+  }
+
+  implicit val catsCollectionPairingHeapUnorderedFoldable: UnorderedFoldable[PairingHeap] =
+    new UnorderedFoldable[PairingHeap] {
+      def unorderedFoldMap[A, B: CommutativeMonoid](ha: PairingHeap[A])(fn: A => B): B =
+        ha.unorderedFoldMap(fn)
+
+      override def unorderedFold[A: CommutativeMonoid](ha: PairingHeap[A]): A =
+        ha.unorderedFold
+
+      override def isEmpty[A](h: PairingHeap[A]) = h.isEmpty
+      override def nonEmpty[A](h: PairingHeap[A]) = h.nonEmpty
+      override def exists[A](ha: PairingHeap[A])(fn: A => Boolean) = ha.exists(fn)
+      override def forall[A](ha: PairingHeap[A])(fn: A => Boolean) = ha.forall(fn)
+      override def size[A](h: PairingHeap[A]) = h.size
+    }
+
+  private[collections] class PairingHeapOrder[A](implicit ordA: Order[A]) extends Order[PairingHeap[A]] {
+    @tailrec
+    final def compare(left: PairingHeap[A], right: PairingHeap[A]): Int =
+      if (left.isEmpty) {
+        if (right.isEmpty) 0
+        else -1
+      }
+      else if (right.isEmpty) 1
+      else {
+        val lt = left.asInstanceOf[Tree[A]]
+        val rt = right.asInstanceOf[Tree[A]]
+        val c = ordA.compare(lt.min, rt.min)
+        if (c != 0) c
+        else compare(left.remove, right.remove)
+      }
+  }
+  /**
+   * This is the same order as you would get by doing `.toList` and ordering by that
+   */
+  implicit def catsCollectionPairingHeapOrder[A: Order]: Order[PairingHeap[A]] =
+    new PairingHeapOrder[A]
+
+
+  implicit def catsCollectionPairingHeapCommutativeMonoid[A: Order]: CommutativeMonoid[PairingHeap[A]] =
+    new CommutativeMonoid[PairingHeap[A]] {
+      def empty = PairingHeap.empty[A]
+      def combine(a: PairingHeap[A], b: PairingHeap[A]) = a.combine(b)
+      override def combineAll(as: TraversableOnce[PairingHeap[A]]): PairingHeap[A] =
+        combineAllIter(as.toIterator, Nil)
+    }
+}

--- a/core/src/main/scala/cats/collections/PairingHeap.scala
+++ b/core/src/main/scala/cats/collections/PairingHeap.scala
@@ -225,7 +225,7 @@ object PairingHeap {
       heap
     }
 
-  private case class Tree[A](min: A, subtrees: List[PairingHeap[A]]) extends PairingHeap[A] {
+  private[collections] final case class Tree[A](min: A, subtrees: List[PairingHeap[A]]) extends PairingHeap[A] {
     override val size = {
       @tailrec
       def loop(ts: List[PairingHeap[A]], acc: Long): Long =
@@ -271,7 +271,7 @@ object PairingHeap {
       }
   }
 
-  private case object Leaf extends PairingHeap[Nothing] {
+  private final case object Leaf extends PairingHeap[Nothing] {
     def apply[A](): PairingHeap[A] = this.asInstanceOf[PairingHeap[A]]
 
     def unapply[A](heap: PairingHeap[A]): Boolean = heap.isEmpty

--- a/core/src/main/scala/cats/collections/PairingHeap.scala
+++ b/core/src/main/scala/cats/collections/PairingHeap.scala
@@ -141,6 +141,8 @@ sealed abstract class PairingHeap[A] {
    * Alias for add
    */
   def +(x: A)(implicit order: Order[A]): PairingHeap[A] = add(x)
+
+  private[collections] def subtrees: List[PairingHeap[A]]
 }
 
 object PairingHeap {
@@ -273,6 +275,8 @@ object PairingHeap {
     def apply[A](): PairingHeap[A] = this.asInstanceOf[PairingHeap[A]]
 
     def unapply[A](heap: PairingHeap[A]): Boolean = heap.isEmpty
+
+    override def subtrees: List[PairingHeap[Nothing]] = Nil
 
     override def size: Long = 0L
 

--- a/core/src/main/scala/cats/collections/PairingHeap.scala
+++ b/core/src/main/scala/cats/collections/PairingHeap.scala
@@ -165,16 +165,17 @@ object PairingHeap {
     }
 
   @tailrec
-  private def combineAllIter[A: Order](iter: Iterator[PairingHeap[A]], tail: List[PairingHeap[A]]): PairingHeap[A] =
+  private def combineAllIter[A: Order](iter: Iterator[PairingHeap[A]], pairs: List[PairingHeap[A]]): PairingHeap[A] =
     if (iter.isEmpty) {
-      combineLoop(tail, empty[A])
+      combineLoop(pairs, empty[A])
     }
     else {
       val p0 = iter.next()
-      if (iter.isEmpty) combineLoop(tail, p0)
+      if (iter.isEmpty) combineLoop(pairs, p0)
       else {
         val p1 = iter.next()
-        combineAllIter(iter, p1 :: p0 :: tail)
+        val pair = p0.combine(p1) // this is where the name pairing heap comes from
+        combineAllIter(iter, pair :: pairs)
       }
     }
 

--- a/core/src/main/scala/cats/collections/PairingHeap.scala
+++ b/core/src/main/scala/cats/collections/PairingHeap.scala
@@ -347,7 +347,5 @@ object PairingHeap {
     new CommutativeMonoid[PairingHeap[A]] {
       def empty = PairingHeap.empty[A]
       def combine(a: PairingHeap[A], b: PairingHeap[A]) = a.combine(b)
-      override def combineAll(as: TraversableOnce[PairingHeap[A]]): PairingHeap[A] =
-        combineAllIter(as.toIterator, Nil)
     }
 }

--- a/core/src/main/scala/cats/collections/PairingHeap.scala
+++ b/core/src/main/scala/cats/collections/PairingHeap.scala
@@ -26,7 +26,7 @@ sealed abstract class PairingHeap[A] {
     if (this.isEmpty) apply(x)
     else {
       val thisTree = this.asInstanceOf[Tree[A]]
-      if (order.lteqv(x, thisTree.min)) Tree(x, this :: Nil)
+      if (order.lt(x, thisTree.min)) Tree(x, this :: Nil)
       else Tree(thisTree.min, Tree(x, Nil) :: thisTree.subtrees)
     }
 

--- a/core/src/main/scala/cats/collections/PairingHeap.scala
+++ b/core/src/main/scala/cats/collections/PairingHeap.scala
@@ -178,20 +178,6 @@ object PairingHeap {
       }
     }
 
-  // this is a combineall that only counts the number of combines is needs
-  // to do for testing
-  // this should be kept in sync with combineAllIter
-  private[collections] def combineAllIterCount[A: Order](iter: Iterator[PairingHeap[A]], cnt: Int): Int =
-    if (iter.isEmpty) cnt
-    else {
-      iter.next()
-      if (iter.isEmpty) cnt + 1
-      else {
-        iter.next()
-        combineAllIterCount(iter, cnt + 2)
-      }
-    }
-
   /**
    * build a heap from a list of items, O(N)
    */

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -204,4 +204,10 @@ class HeapSpec extends CatsSuite {
       assert(Heap.takeLargest(as, k).toList.reverse == as.toList.sorted.reverse.take(k))
     }
   }
+
+  test("Heap.toPairingHeap.toList == Heap.toList") {
+    forAll { (h: Heap[Int]) =>
+      assert(h.toPairingHeap.toList == h.toList)
+    }
+  }
 }

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -114,10 +114,10 @@ class HeapSpec extends CatsSuite {
     }
   }
 
-  test("getMin after removing one is >= before") {
+  test("minimumOption after removing one is >= before") {
     forAll { (heap: Heap[Int]) =>
-      val min0 = heap.getMin
-      val min1 = heap.remove.getMin
+      val min0 = heap.minimumOption
+      val min1 = heap.remove.minimumOption
 
       (min0, min1) match {
         case (None, next) => assert(next.isEmpty)
@@ -128,9 +128,9 @@ class HeapSpec extends CatsSuite {
     }
   }
 
-  test("Heap.getMin is the real minimum") {
+  test("Heap.minimumOption is the real minimum") {
     def heapLaw(heap: Heap[Int]) =
-      heap.getMin match {
+      heap.minimumOption match {
         case None => assert(heap.isEmpty)
         case Some(min) =>
           val heap1 = heap.remove
@@ -147,7 +147,7 @@ class HeapSpec extends CatsSuite {
       heapLaw(heap.remove.remove.remove)
     }
 
-    assert(Heap.empty[Int].getMin.isEmpty)
+    assert(Heap.empty[Int].minimumOption.isEmpty)
   }
 
   test("Heap.foldLeft is consistent with toList.foldLeft") {
@@ -196,6 +196,12 @@ class HeapSpec extends CatsSuite {
       assert(ord.lt(Heap.empty, Heap.empty + item))
       assert(ord.gteqv(heap, Heap.empty))
       assert(ord.gt(Heap.empty + item, Heap.empty))
+    }
+  }
+
+  test("takeLargest is the same as sort.reverse.take") {
+    forAll { (as: Iterable[Int], k: Int) =>
+      assert(Heap.takeLargest(as, k).toList.reverse == as.toList.sorted.reverse.take(k))
     }
   }
 }

--- a/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
@@ -1,0 +1,219 @@
+package cats.collections
+package tests
+
+import cats.{Order, Show, UnorderedFoldable}
+import cats.laws.discipline.UnorderedFoldableTests
+import cats.kernel.laws.discipline.{CommutativeMonoidTests, OrderTests}
+import cats.tests.CatsSuite
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+
+class PairingHeapSpec extends CatsSuite {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    checkConfiguration.copy(
+      minSuccessful = 10000
+    )
+
+  def heapGen[A: Order](size: Int, agen: Gen[A]): Gen[PairingHeap[A]] = {
+    val listA = Gen.listOfN(size, agen)
+    val startWith1 =
+      listA.map {
+        case Nil => PairingHeap.empty[A]
+        case h :: tail => tail.foldLeft(PairingHeap(h))(_.add(_))
+      }
+    val addOnly = listA.map(_.foldLeft(PairingHeap.empty[A])(_.add(_)))
+    val heapify = listA.map(PairingHeap.fromIterable(_))
+    // This one is recursive and with small probability can get quite deep
+    val addMoreAndRemove: Gen[PairingHeap[A]] =
+      for {
+        extraSize <- Gen.choose(1, size + 1)
+        withExtra <- Gen.lzy(heapGen[A](size + extraSize, agen))
+      } yield (0 until extraSize).foldLeft(withExtra) { (h, _) => h.remove }
+    // we can also make smaller one and add to it:
+    val smallerAdd =
+      if (size > 0) {
+        for {
+          a <- agen
+          heap <- heapGen(size - 1, agen)
+        } yield heap + a
+      }
+      else Gen.const(PairingHeap.empty[A])
+
+    val merged =
+      for {
+        rightSize <- Gen.choose(0, size)
+        leftSize = size - rightSize
+        right <- heapGen(rightSize, agen)
+        left <- heapGen(leftSize, agen)
+      } yield right.combine(left)
+
+    Gen.frequency((2, addOnly), (3, startWith1), (5, heapify), (1, addMoreAndRemove), (1, smallerAdd), (1, merged))
+  }
+
+  implicit def arbPairingHeap[A: Arbitrary: Order]: Arbitrary[PairingHeap[A]] =
+    Arbitrary {
+      Gen.sized(heapGen[A](_, Arbitrary.arbitrary[A]))
+    }
+
+  implicit def cogenPairingHeap[A: Cogen: Order]: Cogen[PairingHeap[A]] =
+    Cogen[List[A]].contramap { h: PairingHeap[A] => h.toList }
+
+  checkAll("UnorderedFoldable[PairingHeap]",
+    UnorderedFoldableTests[PairingHeap].unorderedFoldable[Long, Int])
+
+  checkAll("Order[PairingHeap[Int]]", OrderTests[PairingHeap[Int]].order)
+
+  checkAll("PairingHeap[Int]", CommutativeMonoidTests[PairingHeap[Int]].commutativeMonoid)
+
+  test("sorted")(
+    forAll { (list: List[Int]) =>
+
+      val heap = list.foldLeft(PairingHeap.empty[Int])((h, i) => h.add(i))
+
+      heap.toList should be(list.sorted)
+
+    })
+
+  test("fromIterable is sorted") {
+    forAll { (list: List[Int]) =>
+      val heap = PairingHeap.fromIterable(list)
+      val heapList = heap.toList
+      val heap1 = PairingHeap.fromIterable(heapList)
+
+      assert(heapList == list.sorted)
+      assert(Order[PairingHeap[Int]].eqv(heap, heap1))
+    }
+  }
+
+  test("adding increases size") {
+    forAll { (heap: PairingHeap[Int], x: Int) =>
+      val heap1 = heap + x
+      assert(heap1.size == (heap.size + 1))
+    }
+  }
+
+  test("remove decreases size") {
+    forAll { (heap: PairingHeap[Int]) =>
+      val heap1 = heap.remove
+      assert((heap1.size == (heap.size - 1)) || (heap1.isEmpty && heap.isEmpty))
+    }
+
+    assert(PairingHeap.empty[Int].remove == PairingHeap.empty[Int])
+  }
+
+  test("size is consistent with isEmpty/nonEmpty") {
+    forAll { (heap: PairingHeap[Int]) =>
+      assert(heap.isEmpty == (heap.size == 0))
+      assert(heap.nonEmpty == (heap.size > 0))
+      assert(heap.isEmpty == (!heap.nonEmpty))
+    }
+  }
+
+  test("fromIterable is the same as adding") {
+    forAll { (init: List[Int]) =>
+      val heap1 = PairingHeap.fromIterable(init)
+      val heap2 = init.foldLeft(PairingHeap.empty[Int])(_.add(_))
+      assert(heap1.toList == heap2.toList)
+    }
+  }
+
+  test("minimumOption after removing one is >= before") {
+    forAll { (heap: PairingHeap[Int]) =>
+      val min0 = heap.minimumOption
+      val min1 = heap.remove.minimumOption
+
+      (min0, min1) match {
+        case (None, next) => assert(next.isEmpty)
+        case (_, None) => assert(heap.size == 1)
+        case (Some(m0), Some(m1)) =>
+          assert(m0 <= m1)
+      }
+    }
+  }
+
+  test("PairingHeap.minimumOption is the real minimum") {
+    def heapLaw(heap: PairingHeap[Int]) =
+      heap.minimumOption match {
+        case None => assert(heap.isEmpty)
+        case Some(min) =>
+          val heap1 = heap.remove
+          assert(heap1.isEmpty || {
+            min <= heap1.toList.min
+          })
+      }
+
+    forAll { (heap: PairingHeap[Int]) =>
+      heapLaw(heap)
+      // even after removing this is true
+      heapLaw(heap.remove)
+      heapLaw(heap.remove.remove)
+      heapLaw(heap.remove.remove.remove)
+    }
+
+    assert(PairingHeap.empty[Int].minimumOption.isEmpty)
+  }
+
+  test("PairingHeap.foldLeft is consistent with toList.foldLeft") {
+    forAll { (heap: PairingHeap[Int], init: Long, fn: (Long, Int) => Long) =>
+      assert(heap.foldLeft(init)(fn) == heap.toList.foldLeft(init)(fn))
+    }
+  }
+
+  test("Show[PairingHeap[Int]] works like toList.mkString") {
+    forAll { (heap: PairingHeap[Int]) =>
+      assert(Show[PairingHeap[Int]].show(heap) == heap.toList.mkString("PairingHeap(", ", ", ")"))
+    }
+  }
+
+  test("Order[PairingHeap[Int]] works like List[Int]") {
+    forAll { (a: PairingHeap[Int], b: PairingHeap[Int]) =>
+      assert(Order[PairingHeap[Int]].compare(a, b) == Order[List[Int]].compare(a.toList, b.toList))
+    }
+  }
+
+  test("UnorderedFoldable[PairingHeap].size is correct") {
+    forAll { (a: PairingHeap[Int]) =>
+      val uof = UnorderedFoldable[PairingHeap]
+      assert(uof.size(a) == a.size)
+      assert(uof.unorderedFoldMap(a)(_ => 1L) == a.size)
+      assert(a.size == a.toList.size.toLong)
+    }
+  }
+
+  test("PairingHeap.exists is correct") {
+    forAll { (a: PairingHeap[Int], fn: Int => Boolean) =>
+      assert(a.exists(fn) == a.toList.exists(fn))
+    }
+  }
+
+  test("PairingHeap.forall is correct") {
+    forAll { (a: PairingHeap[Int], fn: Int => Boolean) =>
+      assert(a.forall(fn) == a.toList.forall(fn))
+    }
+  }
+
+  test("PairingHeap.empty is less than nonEmpty") {
+    forAll { (item: Int, heap: PairingHeap[Int]) =>
+      val ord = Order[PairingHeap[Int]]
+      assert(ord.lteqv(PairingHeap.empty, heap))
+      assert(ord.lt(PairingHeap.empty, PairingHeap.empty + item))
+      assert(ord.gteqv(heap, PairingHeap.empty))
+      assert(ord.gt(PairingHeap.empty + item, PairingHeap.empty))
+    }
+  }
+
+  test("PairingHeap.combineAll (remove) does < 2 log_2 N work") {
+    forAll { (heaps: List[PairingHeap[Int]]) =>
+      val totalSize = heaps.map(_.size).sum
+
+      val bound = if (totalSize > 0) (math.log(totalSize.toDouble) + 1.0).toInt else 1
+      assert(PairingHeap.combineAllIterCount(heaps.iterator, 0) <= 2.0 * bound)
+    }
+  }
+
+  test("takeLargest is the same as sort.reverse.take") {
+    forAll { (as: Iterable[Int], k: Int) =>
+      assert(PairingHeap.takeLargest(as, k).toList.reverse == as.toList.sorted.reverse.take(k))
+    }
+  }
+}

--- a/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
@@ -204,11 +204,33 @@ class PairingHeapSpec extends CatsSuite {
 
   test("PairingHeap.combineAll (remove) does < log_2 N + 8 work") {
     forAll { (heap: PairingHeap[Int]) =>
-      val totalSize = heap.size
+      def isGood(heap: PairingHeap[Int]): Unit = {
+        val totalSize = heap.size
 
-      val bound = if (totalSize > 0) (math.log(totalSize.toDouble) + 8.0).toInt else 1
-      assert(heap.subtrees.size <= bound)
+        val bound = if (totalSize > 0) (math.log(totalSize.toDouble) + 8.0).toInt else 1
+        assert(heap.subtrees.size <= bound)
+        heap.subtrees.foreach(isGood(_))
+      }
+
+      isGood(heap)
     }
+  }
+
+  test("PairingHeap satisfies the heap property") {
+    def isHeap[A: Order](h: PairingHeap[A]): Unit =
+      h.minimumOption match {
+        case None =>
+          assert(h.subtrees.isEmpty)
+          assert(h.isEmpty)
+          ()
+        case Some(m) =>
+          h.subtrees.foreach { sh =>
+            sh.minimumOption.foreach { sm => assert(Order[A].lteqv(m, sm)) }
+            isHeap(sh)
+          }
+      }
+
+    forAll { (h: PairingHeap[Int]) => isHeap(h) }
   }
 
   test("takeLargest is the same as sort.reverse.take") {

--- a/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
@@ -207,7 +207,7 @@ class PairingHeapSpec extends CatsSuite {
       val totalSize = heap.size
 
       val bound = if (totalSize > 0) (math.log(totalSize.toDouble) + 8.0).toInt else 1
-      assert(PairingHeap.combineAllIterCount(heap.subtrees.iterator, 0) <= bound)
+      assert(heap.subtrees.size <= bound)
     }
   }
 

--- a/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
@@ -202,12 +202,12 @@ class PairingHeapSpec extends CatsSuite {
     }
   }
 
-  test("PairingHeap.combineAll (remove) does < 2 log_2 N work") {
-    forAll { (heaps: List[PairingHeap[Int]]) =>
-      val totalSize = heaps.map(_.size).sum
+  test("PairingHeap.combineAll (remove) does < log_2 N + 8 work") {
+    forAll { (heap: PairingHeap[Int]) =>
+      val totalSize = heap.size
 
-      val bound = if (totalSize > 0) (math.log(totalSize.toDouble) + 1.0).toInt else 1
-      assert(PairingHeap.combineAllIterCount(heaps.iterator, 0) <= 2.0 * bound)
+      val bound = if (totalSize > 0) (math.log(totalSize.toDouble) + 8.0).toInt else 1
+      assert(PairingHeap.combineAllIterCount(heap.subtrees.iterator, 0) <= bound)
     }
   }
 


### PR DESCRIPTION
closes #165 

Also adds a utility method `takeLargest` which is big use of heaps: taking the top-k elements.

cc @ttim @larsrh 