### PR TITLE
Add a fast immutable BitSet implementation

### DIFF
--- a/bench/src/main/scala/BitSetBenchmarks.scala
+++ b/bench/src/main/scala/BitSetBenchmarks.scala
@@ -1,0 +1,131 @@
+package cats.collections
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+import scala.collection.{immutable, mutable}
+import scala.math.pow
+import scala.util.Random
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class BitSetBenchmarks {
+
+  // ranges from 0.0 to 1.0.
+  @Param(Array("0.5"))
+  var density: Double = _
+
+  // creates bitsets of size 2^k (2^10 = 1024, 2^20 = ~1M).
+  @Param(Array("10"))
+  var exponent: Int = _
+
+  var size: Int = _
+  var indices: Array[Int] = _
+
+  var values: Array[Int] = _
+  var sci: immutable.BitSet = _
+  var scm: mutable.BitSet = _
+  var iset: immutable.Set[Int] = _
+  var ccbs: _root_.cats.collections.BitSet = _
+
+  var values2: Array[Int] = _
+  var sci2: immutable.BitSet = _
+  var scm2: mutable.BitSet = _
+  var iset2: immutable.Set[Int] = _
+  var ccbs2: _root_.cats.collections.BitSet = _
+
+  @Setup
+  def setup(): Unit = {
+    size = pow(2, exponent.toDouble).toInt
+
+    val r = new Random(0x13572468)
+
+    values = (0 until size).iterator.filter { _ =>
+      r.nextDouble < density
+    }.toArray
+
+    sci = immutable.BitSet(values: _*)
+    scm = mutable.BitSet(values: _*)
+    iset = immutable.Set(values: _*)
+    ccbs = _root_.cats.collections.BitSet(values: _*)
+
+    values2 = (0 until size).iterator.filter { _ =>
+      r.nextDouble < density
+    }.toArray
+
+    sci2 = immutable.BitSet(values2: _*)
+    scm2 = mutable.BitSet(values2: _*)
+    iset2 = immutable.Set(values2: _*)
+    ccbs2 = _root_.cats.collections.BitSet(values2: _*)
+
+    val n = size / 20
+    indices = new Array[Int](n)
+    (0 until n).foreach { i =>
+      indices(i) = r.nextInt(size)
+    }
+  }
+
+  @Benchmark
+  def buildSci(): immutable.BitSet =
+    immutable.BitSet(values: _*)
+
+  @Benchmark
+  def buildScm(): mutable.BitSet =
+    mutable.BitSet(values: _*)
+
+  @Benchmark
+  def buildIset(): immutable.Set[Int] =
+    immutable.Set[Int](values: _*)
+
+  @Benchmark
+  def buildCcbs(): _root_.cats.collections.BitSet =
+    _root_.cats.collections.BitSet(values: _*)
+
+  @Benchmark
+  def foldIntoSci(): immutable.BitSet =
+    values.foldLeft(immutable.BitSet.empty)(_ + _)
+
+  @Benchmark
+  def foldIntoScm(): mutable.BitSet = {
+    val b = mutable.BitSet.empty
+    values.foreach(b += _)
+    b
+  }
+
+  @Benchmark
+  def foldIntoIset(): immutable.Set[Int] =
+    values.foldLeft(immutable.Set.empty[Int])(_ + _)
+
+  @Benchmark
+  def foldIntoCcbs(): _root_.cats.collections.BitSet =
+    values.foldLeft(_root_.cats.collections.BitSet.empty)(_ + _)
+
+  @Benchmark
+  def lookupSci(): Int = indices.count(i => sci(i))
+
+  @Benchmark
+  def lookupScm(): Int = indices.count(i => scm(i))
+
+  @Benchmark
+  def lookupIset(): Int = indices.count(i => iset(i))
+
+  @Benchmark
+  def lookupCcbs(): Int = indices.count(i => ccbs(i))
+
+  @Benchmark
+  def mergeSci(): immutable.BitSet = sci | sci2
+
+  @Benchmark
+  def mergeScm(): mutable.BitSet = {
+    val x = scm.clone
+    x |= scm2
+    x
+  }
+
+  @Benchmark
+  def mergeIset(): immutable.Set[Int] = iset | iset2
+
+  @Benchmark
+  def mergeCcbs(): _root_.cats.collections.BitSet = ccbs | ccbs2
+}

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val scalacheck = crossProject(JSPlatform, JVMPlatform)
   .settings(dogsSettings:_*)
   .settings(publishSettings)
   .settings(
-    libraryDependencies += "org.scalacheck" %% "scalacheck" % V.scalaCheckVersion(scalaVersion.value)
+    libraryDependencies += "org.scalacheck" %%% "scalacheck" % V.scalaCheckVersion(scalaVersion.value)
   )
 
 lazy val scalacheckJVM = scalacheck.jvm
@@ -71,6 +71,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
   .settings(noPublishSettings)
   .settings(coverageEnabled := false,
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-minSuccessfulTests", "100"), // increase for stress tests
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-testkit" % V.cats % "test",
       "org.typelevel" %%% "cats-laws"    % V.cats % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
   .settings(noPublishSettings)
   .settings(coverageEnabled := false,
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
-    testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-minSuccessfulTests", "100"), // increase for stress tests
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-minSuccessfulTests", "1000"), // "-verbosity", "2"), // increase for stress tests
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-testkit" % V.cats % "test",
       "org.typelevel" %%% "cats-laws"    % V.cats % "test",

--- a/core/src/main/scala-2.12-/cats/collections/compat/BitSetWrapperSet.scala
+++ b/core/src/main/scala-2.12-/cats/collections/compat/BitSetWrapperSet.scala
@@ -1,0 +1,10 @@
+package cats.collections
+package compat
+
+class BitSetWrapperSet(bitset: BitSet) extends Set[Int] {
+  def contains(i: Int): Boolean = bitset(i)
+  def iterator: Iterator[Int] = bitset.iterator
+  def +(i: Int): BitSetWrapperSet = new BitSetWrapperSet(bitset + i)
+  def -(i: Int): BitSetWrapperSet = new BitSetWrapperSet(bitset - i)
+  override def empty: Set[Int] = BitSet.Empty.toSet
+}

--- a/core/src/main/scala-2.13+/cats/collections/compat/BitSetWrapperSet.scala
+++ b/core/src/main/scala-2.13+/cats/collections/compat/BitSetWrapperSet.scala
@@ -1,0 +1,10 @@
+package cats.collections
+package compat
+
+class BitSetWrapperSet(bitset: BitSet) extends Set[Int] {
+  def contains(i: Int): Boolean = bitset(i)
+  def iterator: Iterator[Int] = bitset.iterator
+  def incl(i: Int): BitSetWrapperSet = new BitSetWrapperSet(bitset + i)
+  def excl(i: Int): BitSetWrapperSet = new BitSetWrapperSet(bitset - i)
+  override def empty: Set[Int] = BitSet.Empty.toSet
+}

--- a/core/src/main/scala/cats/collections/BitSet.scala
+++ b/core/src/main/scala/cats/collections/BitSet.scala
@@ -295,7 +295,7 @@ sealed abstract class BitSet { lhs =>
         val it0 = this.iterator
         val it1 = t.iterator
         while (it0.hasNext && it1.hasNext) {
-          if (it0.next != it1.next) return false
+          if (it0.next() != it1.next()) return false
         }
         it0.hasNext == it1.hasNext
       case _ =>
@@ -313,7 +313,7 @@ sealed abstract class BitSet { lhs =>
     var hash: Int = 1500450271 // prime number
     val it = iterator
     while (it.hasNext) {
-      hash = (hash * 1023465798) + it.next // prime number
+      hash = (hash * 1023465798) + it.next() // prime number
     }
     hash
   }
@@ -347,8 +347,9 @@ object BitSet {
    */
   def apply(xs: Int*): BitSet = {
     var bs = newEmpty(0)
-    xs.foreach { n =>
-      bs = bs.mutableAdd(n)
+    val iter = xs.iterator
+    while(iter.hasNext) {
+      bs = bs.mutableAdd(iter.next())
     }
     bs
   }
@@ -425,13 +426,13 @@ object BitSet {
 
     def isEmpty: Boolean = {
       var idx = 0
-      var empty = true
-      while((idx < children.length) && empty) {
+      while(idx < children.length) {
         val c = children(idx)
-        empty = (c == null) || c.isEmpty
+        val empty = (c == null) || c.isEmpty
+        if (!empty) return false
         idx += 1
       }
-      empty
+      true
     }
 
     def newChild(i: Int): BitSet = {
@@ -688,12 +689,12 @@ object BitSet {
 
     def isEmpty: Boolean = {
       var idx = 0
-      var empty = true
-      while ((idx < values.length) && empty) {
-        empty = (values(idx) == 0L)
+      while (idx < values.length) {
+        val empty = (values(idx) == 0L)
+        if (!empty) return false
         idx += 1
       }
-      empty
+      true
     }
 
     def size: Int = {

--- a/core/src/main/scala/cats/collections/BitSet.scala
+++ b/core/src/main/scala/cats/collections/BitSet.scala
@@ -5,30 +5,168 @@ import scala.annotation.tailrec
 
 import BitSet.{Branch, Empty, Leaf}
 
+// This implementation uses a lot of tricks for performance, which
+// scalastyle is not always happy with. So we disable it.
+//
+// scalastyle:off
+
 /**
- * A fast immutable BitSet which unlike scala's default immutable BitSet does
- * not do a full copy on each add. Interally it is based on a Tree of Array[Long].
- * The benchmarks suggest this is MUCH faster for cases where you need many modifications
- * and merges, e.g. a BloomFilter.
+ * A fast, immutable BitSet.
+ *
+ * A Bitset is a specialized type of set that tracks the `Int` values
+ * it contains: for each integer value, a BitSet uses a single bit to
+ * track whether the value is present (1) or absent (0). Bitsets are
+ * often sparse, since "missing" bits can be assumed to be zero.
+ *
+ * Unlike scala's default immutable this BitSet does not do a full
+ * copy on each added value.
+ *
+ * Interally the implementation is a tree. Each leaf uses an
+ * Array[Long] value to hold up to 2048 bits, and each branch uses an
+ * Array[BitSet] to hold up to 32 subtrees (null subtrees are treated
+ * as empty).
+ *
+ * Bitset treats the values it stores as 32-bit unsigned values, which
+ * is relevant to the internal addressing methods as well as the order
+ * used by `iterator`.
+ *
+ * The benchmarks suggest this bitset is MUCH faster than Scala's
+ * built-in bitset for cases where you may need many modifications and
+ * merges, (for example in a BloomFilter).
  */
 sealed abstract class BitSet { lhs =>
 
+  /**
+   * Offset is the first value that this subtree contains.
+   *
+   * Offset will always be a multiple of 2048 (2^11).
+   *
+   * The `offset` is interpreted as a 32-bit unsigned integer. In
+   * other words, `(offset & 0xffffffffL)` will return the equivalent
+   * value as a signed 64-bit integer (between 0 and 4294967295).
+   */
   private[collections] def offset: Int
+
+  /**
+   * Limit is the first value beyond the range this subtree
+   * supports.
+   *
+   * In other words, the last value in the subtree's range is `limit - 1`.
+   * Like `offset`, `limit` will always be a multiple of 2048.
+   *
+   * Offset, limit, and height are related:
+   *
+   *     limit = offset + (32^height) * 2048
+   *     limit > offset (assuming both values are unsigned)
+   *
+   * Like `offset`, `limit` is interpreted as a 32-bit unsigned
+   * integer.
+   */
   private[collections] def limit: Long
+
+  /**
+   * Height represents the number of "levels" this subtree contains.
+   *
+   * For leaves, height is zero. For branches, height will always be
+   * between 1 and 5. This is because a branch with offset=0 and
+   * height=5 will have limit=68719476736, which exceeds the largest
+   * unsigned 32-bit value we might want to store (4294967295).
+   *
+   * The calculation `(32^height) * 2048` tells you how many values a
+   * subtree contains (i.e. how many bits it holds).
+   */
   private[collections] def height: Int
 
+  /**
+   * Look for a particular value in the bitset.
+   *
+   * Returns whether this value's bit is set.
+   */
   def apply(n: Int): Boolean
 
+  /**
+   * Return a bitset that contains `n` and whose other values are
+   * identical to this one's. If this bitset already contains `n` then this
+   * method does nothing.
+   */
   def +(n: Int): BitSet
+
+  /**
+   * Return a bitset that does not contain `n` and whose other values
+   * are identical to this one's. If this bitset does not contain `n`
+   * then this method does nothing.
+   */
   def -(n: Int): BitSet
 
+  /**
+   * Return the union of two bitsets as a new immutable bitset.
+   *
+   * If either bitset contains a given value, the resulting bitset
+   * will also contain it.
+   */
   def |(rhs: BitSet): BitSet
+
+  /**
+   * Return the intersection of two bitsets as a new immutable bitset.
+   *
+   * The resulting bitset will only contain a value if that value is
+   * present in both input bitsets.
+   */
   def &(rhs: BitSet): BitSet
 
+  // Internal mutability
+  //
+  // The following three methods (`+=`, `-=`, and `mutableAdd`) all
+  // potentially mutate `this`.
+  //
+  // These methods are used internally by BitSet's public methods to
+  // mutate newly-constructed trees before returning them to the
+  // caller. This allows us to avoid unnecessary allocations when we
+  // are doing a high-level operation which may result in many
+  // separate modifications.
+
+  /**
+   * Add a single value `n` to this bitset.
+   *
+   * This method modifies this bitset. We require that the value `n`
+   * is in this node's range (i.e. `offset <= n < limit`).
+   */
   private[collections] def +=(n: Int): Unit
+
+  /**
+   * Add all values from `rhs` to this bitset.
+   *
+   * This method modifies this bitset. We require that `this` and
+   * `rhs` are aligned (i.e. they both must have the same `offset` and
+   * `height`).
+   */
   private[collections] def |=(rhs: BitSet): Unit
+
+  /**
+   * Add a single value `n` to this bitset to this bitset or to the
+   * smallest valid bitset that could contain it.
+   *
+   * Unlike `+=` this method can be called with `n` outside of this
+   * node's range. If the value is in range, the method is equivalent
+   * to `+=` (and returns `this`). Otherwise, it wraps `this` in new
+   * branches until the node's range is large enough to contain `n`,
+   * then adds the value to that node, and returns it.
+   */
   private[collections] def mutableAdd(n: Int): BitSet
 
+  /**
+   * Return a compacted bitset containing the same values as this one.
+   *
+   * This method is used to prune out "empty" branches that don't
+   * contain values. By default, bitset does not try to remove empty
+   * leaves when removing values (since repeatedly checking for this
+   * across many deletions would be expensive).
+   *
+   * The bitset returned will have the same values as the current
+   * bitset, but is guaranteed not to contain any empty branches.
+   * Empty branches are not usually observable but would result in
+   * increased memory usage.
+   */
   def compact: BitSet = {
     def recur(x: BitSet): BitSet =
       x match {
@@ -59,22 +197,49 @@ sealed abstract class BitSet { lhs =>
     if (res == null) Empty else res
   }
 
+  /**
+   * Returns the number of distinct values in this bitset.
+   *
+   * For branches, this method will return the sum of the sizes of all
+   * its subtrees. For leaves it returns the number of bits set in the
+   * leaf (i.e. the number of values the leaf contains).
+   */
   def size: Int
+
+  /**
+   * Iterate across all values in the bitset.
+   *
+   * Values in the iterator will be seen in "unsigned order" (e.g. if
+   * present, -1 will always come last). Here's an abbreviated view of
+   * this order in practice:
+   *
+   *   0, 1, 2, ... 2147483646, 2147483647, -2147483648, -2147483647, ... -1
+   *
+   * (This "unsigned order" is identical to the tree's internal order.)
+   */
   def iterator: Iterator[Int]
+
+  /**
+   * Iterate across all values in the bitset in reverse order.
+   *
+   * The order here is exactly the reverse of `.iterator`.
+   */
   def reverseIterator: Iterator[Int]
 
   /**
-   * Implement a wrapper around this set
+   * Present a view of this bitset as a `scala.Set[Int]`.
+   *
+   * This is provided for compatibility with Scala collections. Many
+   * of the set operations are implemented in terms of `BitSet`, but
+   * other operations (for example `map`) may copy these values into a
+   * different `Set` implementation.
    */
   def toSet: Set[Int] =
-    new Set[Int] {
-      def contains(i: Int) = lhs(i)
-      def iterator = lhs.iterator
-      def +(i: Int) = (lhs + i).toSet
-      def -(i: Int) = (lhs - i).toSet
-      override def empty = Empty.toSet
-    }
+    new compat.BitSetWrapperSet(this)
 
+  /**
+   * Returns false if this bitset contains values, true otherwise.
+   */
   def isEmpty: Boolean =
     this match {
       case Leaf(_, vs) =>
@@ -86,11 +251,26 @@ sealed abstract class BitSet { lhs =>
         }
     }
 
+  /**
+   * Returns true if this bitset contains values, false otherwise.
+   */
   def nonEmpty: Boolean = !isEmpty
 
+  /**
+   * Produce a string representation of this BitSet.
+   *
+   * This representation will contain all the values in the bitset.
+   * For large bitsets, this operation may be very expensive.
+   */
   override def toString: String =
     iterator.map(_.toString).mkString("BitSet(", ", ", ")")
 
+  /**
+   * Produce a structured representation of this BitSet.
+   *
+   * This representation is for internal-use only. It gives a view of
+   * how the bitset is encoded in a tree, showing leaves and branches.
+   */
   private[collections] def structure: String =
     this match {
       case Branch(o, h, cs) =>
@@ -104,6 +284,17 @@ sealed abstract class BitSet { lhs =>
         s"Leaf($o, $v)"
     }
 
+  /**
+   * Universal equality.
+   *
+   * This method will only return true if the right argument is also a
+   * `BitSet`. It does not attempt to coerce either argument in any
+   * way (unlike Scala collections, for example).
+   *
+   * Two bitsets can be equal even if they have different underlying
+   * tree structure. (For example, one bitset's tree may have empty
+   * branches that the other lacks.)
+   */
   override def equals(that: Any): Boolean =
     that match {
       case t: BitSet =>
@@ -117,25 +308,49 @@ sealed abstract class BitSet { lhs =>
         false
     }
 
+  /**
+   * Universal hash code.
+   *
+   * Bitsets that are the equal will hash to the same value. As in
+   * `equals`, the values present determine the hash code, as opposed
+   * to the tree structure.
+   */
   override def hashCode: Int = {
     var hash: Int = 1500450271 // prime number
     val it = iterator
     while (it.hasNext) {
-      hash = (hash * it.next) + 1023465798 // prime number
+      hash = (hash * 1023465798) + it.next // prime number
     }
     hash
   }
 }
 
 object BitSet {
+
+  /**
+   * Returns an empty immutable bitset.
+   */
   def empty: BitSet = Empty
 
+  /**
+   * Singleton value representing an empty bitset.
+   */
   final val Empty: BitSet =
     newEmpty(0)
 
+  /**
+   * Returns an empty leaf.
+   *
+   * This is used internally with the assumption that it will be
+   * mutated to "add" values to it. In cases where no values need to
+   * be added, `empty` should be used instead.
+   */
   private[collections] def newEmpty(offset: Int): BitSet =
     Leaf(offset, new Array[Long](32))
 
+  /**
+   * Construct an immutable bitset from the given integer values.
+   */
   def apply(xs: Int*): BitSet = {
     var bs = newEmpty(0)
     xs.foreach { n =>
@@ -144,14 +359,28 @@ object BitSet {
     bs
   }
 
+  /**
+   * Given a value (`n`), and offset (`o`) and a height (`h`), compute
+   * the array index used to store the given value's bit.
+   */
   @inline private[collections] def index(n: Int, o: Int, h: Int): Int =
     (n - o) >>> (h * 5 + 6)
 
+  /**
+   * Given an offset (`o`) and a height (`h`) representing a subtree,
+   * compute the array index used this subtree in its parent tree.
+   */
   @inline private[collections] def parentOffset(o: Int, h: Int): Int =
     o & -(1 << (h * 5 + 16))
 
   case class InternalError(msg: String) extends Exception(msg)
 
+  /**
+   * Construct the leaf containing the given value `n`.
+   *
+   * Since leaves have zero height, we can divide a value by 2048
+   * (i.e. >> 11) to determine its offset.
+   */
   private[collections] def leafFor(n: Int): BitSet = {
     val offset = n >>> 11
     val i = (n - offset) >>> 5
@@ -161,6 +390,12 @@ object BitSet {
     Leaf(offset, vs)
   }
 
+  /**
+   * Return a branch containing the given bitset `b` and value `n`.
+   *
+   * This method assumes that `n` is outside of the range of `b`. It
+   * will return the smallest branch that contains both `b` and `n`.
+   */
   private def adoptedPlus(b: BitSet, n: Int): Branch = {
     val h = b.height + 1
     val o = b.offset & -(1 << (h * 5 + 11))
@@ -177,6 +412,13 @@ object BitSet {
     }
   }
 
+  /**
+   * Return a branch containing the given bitsets `b` and `rhs`.
+   *
+   * This method assumes that `rhs` is at least partially-outside of
+   * the range of `b`. It will return the smallest branch that
+   * contains both `b` and `rhs`.
+   */
   private def adoptedUnion(b: BitSet, rhs: BitSet): Branch = {
     val h = b.height + 1
     val o = b.offset & -(1 << (h * 5 + 11))
@@ -195,7 +437,7 @@ object BitSet {
 
   private case class Branch(offset: Int, height: Int, children: Array[BitSet]) extends BitSet {
 
-    @inline private[collections] def limit: Long = offset + (1L << height * 5 + 11)
+    @inline private[collections] def limit: Long = offset + (1L << (height * 5 + 11))
 
     //require(limit > offset, s"$limit > $offset (at height=$height)")
 
@@ -543,6 +785,12 @@ object BitSet {
       new LeafReverseIterator(offset, values)
   }
 
+  /**
+   * Efficient, low-level iterator for BitSet.Leaf values.
+   *
+   * As mentioned in `BitSet.iterator`, this method will return values
+   * in unsigned order (e.g. Int.MaxValue comes before Int.MinValue).
+   */
   private class LeafIterator(offset: Int, values: Array[Long]) extends Iterator[Int] {
     var i: Int = 0
     var x: Long = values(0)
@@ -575,6 +823,12 @@ object BitSet {
     }
   }
 
+  /**
+   * Efficient, low-level reversed iterator for BitSet.Leaf values.
+   *
+   * This class is very similar to LeafIterator but returns values in
+   * the reverse order.
+   */
   private class LeafReverseIterator(offset: Int, values: Array[Long]) extends Iterator[Int] {
     var i: Int = 31
     var x: Long = values(31)
@@ -607,3 +861,5 @@ object BitSet {
     }
   }
 }
+
+// scalastyle:on

--- a/core/src/main/scala/cats/collections/BitSet.scala
+++ b/core/src/main/scala/cats/collections/BitSet.scala
@@ -596,13 +596,21 @@ object BitSet {
         val Branch(_, _, rcs) = rhs
         val cs = new Array[BitSet](32)
         var i = 0
+        var nonEmpty = false
         while (i < 32) {
           val x = children(i)
           val y = rcs(i)
-          if (x != null && y != null) cs(i) = x & y
+          if (x != null && y != null) {
+            val xy = x & y
+            if (!(xy eq Empty)) {
+              nonEmpty = true
+              cs(i) = xy
+            }
+          }
           i += 1
         }
-        Branch(offset, height, cs)
+        if (nonEmpty) Branch(offset, height, cs)
+        else Empty
       }
 
     def intersects(rhs: BitSet): Boolean =
@@ -639,7 +647,11 @@ object BitSet {
         // TODO: it is unclear why BitSet.Empty isn't okay here.
         // Tests pass if we do it, but it seems a pretty minor optimization
         // If we need some invariant, we should have a test for it.
-        newEmpty(offset)
+        // newEmpty(offset)
+        //
+        // a motivation to use Empty here is to avoid always returning
+        // aligned offsets, which make some of the branches below unreachable
+        BitSet.Empty
       } else if (height > rhs.height) {
         if (rhs.offset < offset || limit <= rhs.offset) {
           this | rhs
@@ -953,7 +965,11 @@ object BitSet {
             // TODO: it is unclear why BitSet.Empty isn't okay here.
             // Tests pass if we do it, but it seems a pretty minor optimization
             // If we need some invariant, we should have a test for it.
-            newEmpty(offset)
+            // newEmpty(offset)
+            //
+            // a motivation to use Empty here is to avoid always returning
+            // aligned offsets, which make some of the branches below unreachable
+            BitSet.Empty
           } else if (o != offset) {
             this | rhs
           } else {

--- a/core/src/main/scala/cats/collections/BitSet.scala
+++ b/core/src/main/scala/cats/collections/BitSet.scala
@@ -1,0 +1,609 @@
+package cats.collections
+
+import java.lang.Long.bitCount
+import scala.annotation.tailrec
+
+import BitSet.{Branch, Empty, Leaf}
+
+/**
+ * A fast immutable BitSet which unlike scala's default immutable BitSet does
+ * not do a full copy on each add. Interally it is based on a Tree of Array[Long].
+ * The benchmarks suggest this is MUCH faster for cases where you need many modifications
+ * and merges, e.g. a BloomFilter.
+ */
+sealed abstract class BitSet { lhs =>
+
+  private[collections] def offset: Int
+  private[collections] def limit: Long
+  private[collections] def height: Int
+
+  def apply(n: Int): Boolean
+
+  def +(n: Int): BitSet
+  def -(n: Int): BitSet
+
+  def |(rhs: BitSet): BitSet
+  def &(rhs: BitSet): BitSet
+
+  private[collections] def +=(n: Int): Unit
+  private[collections] def |=(rhs: BitSet): Unit
+  private[collections] def mutableAdd(n: Int): BitSet
+
+  def compact: BitSet = {
+    def recur(x: BitSet): BitSet =
+      x match {
+        case leaf @ Leaf(_, _) =>
+          if (leaf.isEmpty) null else leaf
+        case Branch(o, h, cs0) =>
+          var i = 0
+          var found: BitSet = null
+          while (i < 32 && found == null) {
+            val c = cs0(i)
+            if (c != null) found = recur(c)
+            i += 1
+          }
+          if (found == null) {
+            null
+          } else {
+            val cs1 = new Array[BitSet](32)
+            cs1(i - 1) = found
+            while (i < 32) {
+              val c = cs0(i)
+              if (c != null) cs1(i) = recur(c)
+              i += 1
+            }
+            Branch(o, h, cs1)
+          }
+      }
+    val res = recur(this)
+    if (res == null) Empty else res
+  }
+
+  def size: Int
+  def iterator: Iterator[Int]
+  def reverseIterator: Iterator[Int]
+
+  /**
+   * Implement a wrapper around this set
+   */
+  def toSet: Set[Int] =
+    new Set[Int] {
+      def contains(i: Int) = lhs(i)
+      def iterator = lhs.iterator
+      def +(i: Int) = (lhs + i).toSet
+      def -(i: Int) = (lhs - i).toSet
+      override def empty = Empty.toSet
+    }
+
+  def isEmpty: Boolean =
+    this match {
+      case Leaf(_, vs) =>
+        vs.forall(_ == 0L)
+      case Branch(_, _, cs) =>
+        cs.forall {
+          case null => true
+          case c => c.isEmpty
+        }
+    }
+
+  def nonEmpty: Boolean = !isEmpty
+
+  override def toString: String =
+    iterator.map(_.toString).mkString("BitSet(", ", ", ")")
+
+  private[collections] def structure: String =
+    this match {
+      case Branch(o, h, cs) =>
+        val s = cs.iterator
+          .zipWithIndex
+          .filter { case (c, _) => c != null }
+          .map { case (c, i) => s"$i -> ${c.structure}" }
+          .mkString("Array(", ", ", ")")
+        s"Branch($o, $h, $s)"
+      case Leaf(o, v) =>
+        s"Leaf($o, $v)"
+    }
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case t: BitSet =>
+        val it0 = this.iterator
+        val it1 = t.iterator
+        while (it0.hasNext && it1.hasNext) {
+          if (it0.next != it1.next) return false
+        }
+        it0.hasNext == it1.hasNext
+      case _ =>
+        false
+    }
+
+  override def hashCode: Int = {
+    var hash: Int = 1500450271 // prime number
+    val it = iterator
+    while (it.hasNext) {
+      hash = (hash * it.next) + 1023465798 // prime number
+    }
+    hash
+  }
+}
+
+object BitSet {
+  def empty: BitSet = Empty
+
+  final val Empty: BitSet =
+    newEmpty(0)
+
+  private[collections] def newEmpty(offset: Int): BitSet =
+    Leaf(offset, new Array[Long](32))
+
+  def apply(xs: Int*): BitSet = {
+    var bs = newEmpty(0)
+    xs.foreach { n =>
+      bs = bs.mutableAdd(n)
+    }
+    bs
+  }
+
+  @inline private[collections] def index(n: Int, o: Int, h: Int): Int =
+    (n - o) >>> (h * 5 + 6)
+
+  @inline private[collections] def parentOffset(o: Int, h: Int): Int =
+    o & -(1 << (h * 5 + 16))
+
+  case class InternalError(msg: String) extends Exception(msg)
+
+  private[collections] def leafFor(n: Int): BitSet = {
+    val offset = n >>> 11
+    val i = (n - offset) >>> 5
+    val j = (n - offset) & 63
+    val vs = new Array[Long](32)
+    vs(i) = 1L << j
+    Leaf(offset, vs)
+  }
+
+  private def adoptedPlus(b: BitSet, n: Int): Branch = {
+    val h = b.height + 1
+    val o = b.offset & -(1 << (h * 5 + 11))
+    val cs = new Array[BitSet](32)
+    val i = (b.offset - o) >>> (h * 5 + 6)
+    cs(i) = b
+    val parent = Branch(o, h, cs)
+    val j = BitSet.index(n, o, h)
+    if (j < 0 || 32 <= j) {
+      adoptedPlus(parent, n)
+    } else {
+      parent += n
+      parent
+    }
+  }
+
+  private def adoptedUnion(b: BitSet, rhs: BitSet): Branch = {
+    val h = b.height + 1
+    val o = b.offset & -(1 << (h * 5 + 11))
+    val cs = new Array[BitSet](32)
+    val i = (b.offset - o) >>> (h * 5 + 6)
+    cs(i) = b
+    val parent = Branch(o, h, cs)
+    val j = BitSet.index(rhs.offset, o, h)
+    if (j < 0 || 32 <= j || rhs.height > parent.height) {
+      adoptedUnion(parent, rhs)
+    } else {
+      parent |= rhs
+      parent
+    }
+  }
+
+  private case class Branch(offset: Int, height: Int, children: Array[BitSet]) extends BitSet {
+
+    @inline private[collections] def limit: Long = offset + (1L << height * 5 + 11)
+
+    //require(limit > offset, s"$limit > $offset (at height=$height)")
+
+    @inline private[collections] def index(n: Int): Int = (n - offset) >>> (height * 5 + 6)
+    @inline private[collections] def valid(i: Int): Boolean = 0 <= i && i < 32
+    @inline private[collections] def invalid(i: Int): Boolean = i < 0 || 32 <= i
+
+    def apply(n: Int): Boolean = {
+      val i = index(n)
+      valid(i) && {
+        val c = children(i)
+        c != null && c(n)
+      }
+    }
+
+    def newChild(i: Int): BitSet = {
+      val o = offset + i * (1 << height * 5 + 6)
+      if (height == 1) BitSet.newEmpty(o)
+      else Branch(o, height - 1, new Array[BitSet](32))
+    }
+
+    def +(n: Int): BitSet = {
+      val i = index(n)
+      if (invalid(i)) {
+        BitSet.adoptedPlus(this, n)
+      } else {
+        val c0 = children(i)
+        val c1 = if (c0 != null) c0 + n else {
+          val cc = newChild(i)
+          cc += n
+          cc
+        }
+        // we already had this item
+        if (c0 eq c1) this
+        else replace(i, c1)
+      }
+    }
+
+    def replace(i: Int, child: BitSet): Branch = {
+      val cs = new Array[BitSet](32)
+      System.arraycopy(children, 0, cs, 0, 32)
+      cs(i) = child
+      copy(children = cs)
+    }
+
+    def -(n: Int): BitSet = {
+      val i = index(n)
+      if (invalid(i)) this
+      else {
+        val c = children(i)
+        if (c == null) this
+        else {
+          val c1 = c - n
+          if (c1 eq c) this // we don't contain n
+          else replace(i, c - n)
+        }
+      }
+    }
+
+    def |(rhs: BitSet): BitSet =
+      if (height > rhs.height) {
+        if (rhs.offset < offset || limit <= rhs.offset) {
+          // this branch doesn't contain rhs
+          BitSet.adoptedUnion(this, rhs)
+        } else {
+          // this branch contains rhs, so find its index
+          val i = index(rhs.offset)
+          val c0 = children(i)
+          val c1 =
+            if (c0 != null) c0 | rhs
+            else if (height == 1) rhs
+            else {
+              val cc = newChild(i)
+              cc |= rhs
+              cc
+            }
+          replace(i, c1)
+        }
+      } else if (height < rhs.height) {
+        // use commuativity to handle this in previous case
+        rhs | this
+      } else if (offset != rhs.offset) {
+        // same height, but non-overlapping
+        BitSet.adoptedUnion(this, rhs)
+      } else {
+        // height == rhs.height, so we know rhs is a Branch.
+        val Branch(_, _, rcs) = rhs
+        val cs = new Array[BitSet](32)
+        var i = 0
+        while (i < 32) {
+          val x = children(i)
+          val y = rcs(i)
+          cs(i) = if (x == null) y else if (y == null) x else x | y
+          i += 1
+        }
+        Branch(offset, height, cs)
+      }
+
+    def &(rhs: BitSet): BitSet =
+      if (height > rhs.height) {
+        if (rhs.offset < offset || limit <= rhs.offset) {
+          Empty
+        } else {
+          // this branch contains rhs, so find its index
+          val i = index(rhs.offset)
+          val c0 = children(i)
+          if (c0 != null) c0 & rhs else Empty
+        }
+      } else if (height < rhs.height) {
+        // use commuativity to handle this in previous case
+        rhs & this
+      } else if (offset != rhs.offset) {
+        // same height, but non-overlapping
+        Empty
+      } else {
+        // height == rhs.height, so we know rhs is a Branch.
+        val Branch(_, _, rcs) = rhs
+        val cs = new Array[BitSet](32)
+        var i = 0
+        while (i < 32) {
+          val x = children(i)
+          val y = rcs(i)
+          if (x != null && y != null) cs(i) = x & y
+          i += 1
+        }
+        Branch(offset, height, cs)
+      }
+
+    private[collections] def +=(n: Int): Unit = {
+      val i = index(n)
+      //require(valid(i))
+      val c0 = children(i)
+      if (c0 == null) {
+        val c = newChild(i)
+        children(i) = c
+        c += n
+      } else {
+        c0 += n
+      }
+    }
+
+    private[collections] def mutableAdd(n: Int): BitSet = {
+      val i = index(n)
+      if (valid(i)) {
+        val c0 = children(i)
+        if (c0 == null) {
+          val c = newChild(i)
+          children(i) = c
+          c += n
+        } else {
+          c0 += n
+        }
+        this
+      } else {
+        BitSet.adoptedPlus(this, n)
+      }
+    }
+
+    private[collections] def |=(rhs: BitSet): Unit =
+      if (height > rhs.height) {
+        if (rhs.offset < offset || limit <= rhs.offset) {
+          throw InternalError("union outside of branch jurisdiction")
+        } else {
+          // this branch contains rhs, so find its index
+          val i = index(rhs.offset)
+          val c0 = children(i)
+          if (c0 == null) {
+            val c1 = newChild(i)
+            c1 |= rhs
+            children(i) = c1
+          } else {
+            c0 |= rhs
+          }
+        }
+      } else if (height < rhs.height) {
+        throw InternalError("branch too short for union")
+      } else if (offset != rhs.offset) {
+        throw InternalError("branch misaligned")
+      } else {
+        // height == rhs.height, so we know rhs is a Branch.
+        val Branch(_, _, rcs) = rhs
+        var i = 0
+        while (i < 32) {
+          val x = children(i)
+          val y = rcs(i)
+          if (x == null) children(i) = y
+          else if (y != null) x |= rcs(i)
+          i += 1
+        }
+      }
+
+    // TODO: optimize
+    def iterator: Iterator[Int] =
+      children.iterator.flatMap {
+        case null => Iterator.empty
+        case c => c.iterator
+      }
+
+    def reverseIterator: Iterator[Int] =
+      children.reverseIterator.flatMap {
+        case null => Iterator.empty
+        case c => c.reverseIterator
+      }
+
+    def size: Int = {
+      var i = 0
+      var n = 0
+      while (i < 32) {
+        val c = children(i)
+        if (c != null) n += c.size
+        i += 1
+      }
+      n
+    }
+  }
+
+  private case class Leaf(offset: Int, private val values: Array[Long]) extends BitSet {
+
+    @inline private[collections] def limit: Long = offset + 2048L
+
+    @inline private[collections] def index(n: Int): Int = (n - offset) >>> 6
+    @inline private[collections] def bit(n: Int): Int = (n - offset) & 63
+    @inline private[collections] def valid(i: Int): Boolean = 0 <= i && i < 2048
+    @inline private[collections] def invalid(i: Int): Boolean = i < 0 || 2048 <= i
+
+    def height: Int = 0
+
+    def apply(n: Int): Boolean = {
+      val i = index(n)
+      (0 <= i && i < 32) && (((values(i) >>> bit(n)) & 1) == 1)
+    }
+
+    def arrayCopy: Array[Long] = {
+      val vs = new Array[Long](32)
+      System.arraycopy(values, 0, vs, 0, 32)
+      vs
+    }
+
+    def +(n: Int): BitSet = {
+      val i = index(n)
+      if (0 <= i && i < 32) {
+        val mask = 1L << bit(n)
+        val vsi = values(i)
+        if ((vsi & mask) == 1L) this
+        else {
+          val vs = arrayCopy
+          vs(i) = vsi | mask
+          Leaf(offset, vs)
+        }
+      } else {
+        BitSet.adoptedPlus(this, n)
+      }
+    }
+
+    def -(n: Int): BitSet = {
+      val i = index(n)
+      if (i < 0 || 32 <= i) {
+        this
+      } else {
+        val mask = (1L << bit(n))
+        val vsi = values(i)
+        if ((vsi & mask) == 0L) this
+        else {
+          val vs = arrayCopy
+          vs(i) = vsi & (~mask)
+          Leaf(offset, vs)
+        }
+      }
+    }
+
+    def size: Int = {
+      var c = 0
+      var i = 0
+      while (i < 32) {
+        c += bitCount(values(i))
+        i += 1
+      }
+      c
+    }
+
+    def |(rhs: BitSet): BitSet =
+      rhs match {
+        case Leaf(`offset`, values2) =>
+          val vs = new Array[Long](32)
+          var i = 0
+          while (i < 32) {
+            vs(i) = values(i) | values2(i)
+            i += 1
+          }
+          Leaf(offset, vs)
+        case _ =>
+          BitSet.adoptedUnion(this, rhs)
+      }
+
+    def &(rhs: BitSet): BitSet =
+      rhs match {
+        case Leaf(o, values2) =>
+          if (o != offset) {
+            Empty
+          } else {
+            val vs = new Array[Long](32)
+            var i = 0
+            while (i < 32) {
+              vs(i) = values(i) & values2(i)
+              i += 1
+            }
+            Leaf(offset, vs)
+          }
+        case Branch(_, _, _) =>
+          rhs & this
+      }
+
+    private[collections] def +=(n: Int): Unit = {
+      val i = index(n)
+      val j = bit(n)
+      values(i) |= (1L << j)
+    }
+
+    private[collections] def mutableAdd(n: Int): BitSet = {
+      val i = index(n)
+      if (0 <= i && i < 32) {
+        values(i) |= (1L << bit(n))
+        this
+      } else {
+        BitSet.adoptedPlus(this, n)
+      }
+    }
+
+    private[collections] def |=(rhs: BitSet): Unit =
+      rhs match {
+        case Leaf(`offset`, values2) =>
+          var i = 0
+          while (i < 32) {
+            values(i) |= values2(i)
+            i += 1
+          }
+        case _ =>
+          throw InternalError("illegal leaf union")
+      }
+
+    def iterator: Iterator[Int] =
+      new LeafIterator(offset, values)
+
+    def reverseIterator: Iterator[Int] =
+      new LeafReverseIterator(offset, values)
+  }
+
+  private class LeafIterator(offset: Int, values: Array[Long]) extends Iterator[Int] {
+    var i: Int = 0
+    var x: Long = values(0)
+    var n: Int = offset
+
+    @tailrec private def search(): Unit =
+      if (x == 0 && i < 31) {
+        i += 1
+        n = offset + i * 64
+        x = values(i)
+        search()
+      } else ()
+
+    private def advance(): Unit = {
+      x = x >>> 1
+      n += 1
+      search()
+    }
+
+    search()
+
+    def hasNext: Boolean = x != 0
+
+    def next(): Int = {
+      while (x != 0 && (x & 1) == 0) advance()
+      if (x == 0) throw new NoSuchElementException("next on empty iterator")
+      val res = n
+      advance()
+      res
+    }
+  }
+
+  private class LeafReverseIterator(offset: Int, values: Array[Long]) extends Iterator[Int] {
+    var i: Int = 31
+    var x: Long = values(31)
+    var n: Int = offset + (i + 1) * 64 - 1
+
+    @tailrec private def search(): Unit =
+      if (x == 0 && i > 0) {
+        i -= 1
+        n = offset + (i + 1) * 64 - 1
+        x = values(i)
+        search()
+      } else ()
+
+    private def advance(): Unit = {
+      x = x << 1
+      n -= 1
+      search()
+    }
+
+    search()
+
+    def hasNext: Boolean = x != 0
+
+    def next(): Int = {
+      while (x > 0) advance()
+      if (x == 0) throw new NoSuchElementException("next on empty iterator")
+      val res = n
+      advance()
+      res
+    }
+  }
+}

--- a/tests/src/test/scala/cats/collections/BitSetTest.scala
+++ b/tests/src/test/scala/cats/collections/BitSetTest.scala
@@ -1,5 +1,6 @@
 package cats.collections
 
+import cats.implicits._
 import org.scalacheck.Prop._
 import org.scalacheck.{Arbitrary, Gen, Properties}
 import Arbitrary.{arbitrary => arb}
@@ -220,6 +221,125 @@ object BitSetTest extends Properties("BitSet") {
     forAll { (x: BitSet) =>
       val lhs = x.iterator.toList.reverse
       val rhs = x.reverseIterator.toList
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("((x ^ y) ^ z) = (x ^ (y ^ z))") =
+    forAll { (x: BitSet, y: BitSet, z: BitSet) =>
+      val lhs = ((x ^ y) ^ z)
+      val rhs = (x ^ (y ^ z))
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x ^ y) = (y ^ x)") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val lhs = (x ^ y)
+      val rhs = (y ^ x)
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x ^ x) = 0") =
+    forAll { (x: BitSet) =>
+      val lhs = (x ^ x)
+      val rhs = BitSet.empty
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x ^ 0) = x") =
+    forAll { (x: BitSet) =>
+      val lhs = (x ^ BitSet.empty)
+      val rhs = x
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x ^ y)(n) = x(n) ^ y(n)") =
+    forAll { (x: BitSet, y: BitSet, n: Int) =>
+      val lhs = (x ^ y)(n)
+      val rhs = x(n) ^ y(n)
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x ^ y) = ((x -- (x & y)) | (y -- (x & y)))") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val xy = x & y
+      val lhs = x ^ y
+      val rhs = (x -- xy) | (y -- xy)
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x -- y)(n) = x(n) && (!y(n))") =
+    forAll { (x: BitSet, y: BitSet, n: Int) =>
+      val lhs = (x -- y)(n)
+      val rhs = x(n) && (!y(n))
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x -- y).toSet = (x.toSet -- y.toSet)") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val lhs = (x -- y).toSet
+      val rhs = x.toSet -- y.toSet
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("x -- x = 0") =
+    forAll { (x: BitSet) =>
+      val lhs = x -- x
+      val rhs = BitSet.empty
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("0 -- x = 0") =
+    forAll { (x: BitSet) =>
+      val lhs = BitSet.empty -- x
+      val rhs = BitSet.empty
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("x -- BitSet(n) = x - n") =
+    forAll { (x: BitSet, n: Int) =>
+      val lhs = x -- BitSet(n)
+      val rhs = x - n
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("x -- 0 = x") =
+    forAll { (x: BitSet) =>
+      val lhs = x -- BitSet.empty
+      (lhs == x) :| s"$lhs == $x"
+    }
+
+  property("x -- y -- y = x -- y") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val lhs = x -- y -- y
+      val rhs = x -- y
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("test order") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val lhs = x compare y
+      val rhs = x.iterator.toList compare y.iterator.toList
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("test ordering") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val lhs = BitSet.orderingForBitSet.compare(x, y)
+      val rhs = x.iterator.toList compare y.iterator.toList
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x intersects y) = (y intersects x)") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val lhs = x intersects y
+      val rhs = y intersects x
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("(x intersects y) = (x & y).nonEmpty") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val lhs = x intersects y
+      val rhs = (x & y).nonEmpty
       (lhs == rhs) :| s"$lhs == $rhs"
     }
 }

--- a/tests/src/test/scala/cats/collections/BitSetTest.scala
+++ b/tests/src/test/scala/cats/collections/BitSetTest.scala
@@ -1,26 +1,13 @@
 package cats.collections
 
 import org.scalacheck.Prop._
-import org.scalacheck.{Arbitrary, /*Cogen, */Gen, Properties, Test}
+import org.scalacheck.{Arbitrary, Properties}
 import Arbitrary.{arbitrary => arb}
 
 object BitSetTest extends Properties("BitSet") {
 
-  override def overrideParameters(p: Test.Parameters): Test.Parameters =
-    p.withMinSuccessfulTests(500)
-
-  case class N(value: Int) {
-    override def toString: String = value.toString
-  }
-
-  implicit val arbN: Arbitrary[N] =
-    Arbitrary(Gen.choose(0, Int.MaxValue).map(N(_)))
-
-  def build(xs: List[N]): BitSet =
-    xs.foldLeft(BitSet.empty)((bs, n) => bs + n.value)
-
   implicit val arbBitSet: Arbitrary[BitSet] =
-    Arbitrary(arb[List[N]].map(xs => BitSet(xs.map(_.value): _*)))
+    Arbitrary(arb[List[Int]].map(xs => BitSet(xs: _*)))
 
   property("(x = y) = (x.toSet = y.toSet)") =
     forAll { (x: BitSet, y: BitSet) =>
@@ -35,8 +22,7 @@ object BitSetTest extends Properties("BitSet") {
     }
 
   property("BitSet(set: _*).toSet = set") =
-    forAll { (ns0: Set[N]) =>
-      val ns = ns0.map(_.value)
+    forAll { (ns: Set[Int]) =>
       val x = BitSet(ns.toList: _*)
       x.toSet == ns && ns.forall(x(_))
     }
@@ -54,7 +40,10 @@ object BitSetTest extends Properties("BitSet") {
 
   property("(x = y) = (x.## = y.##)") =
     forAll { (x: BitSet, y: BitSet) =>
-      (x == y) == (x.## == y.##) // only approximately true
+      // This is only approximately true, but failures are very rare,
+      // and without something like this its easy to end up with real
+      // hashing bugs.
+      (x == y) == (x.## == y.##)
     }
 
   property("x.compact = x") =
@@ -77,52 +66,50 @@ object BitSetTest extends Properties("BitSet") {
     }
 
   property("(x + a)(a)") =
-    forAll { (x: BitSet, a: N) =>
-      val y = x + a.value
-      y(a.value) :| s"$y(${a.value})"
+    forAll { (x: BitSet, a: Int) =>
+      val y = x + a
+      y(a) :| s"$y(${a})"
     }
 
   property("!(x - a)(a)") =
-    forAll { (x: BitSet, a: N) =>
-      !(x - a.value)(a.value)
+    forAll { (x: BitSet, a: Int) =>
+      !(x - a)(a)
     }
 
   property("x + a - a == x - a") =
-    forAll { (x: BitSet, a: N) =>
-      ((x + a.value) - a.value) == (x - a.value)
+    forAll { (x: BitSet, a: Int) =>
+      ((x + a) - a) == (x - a)
     }
 
   property("x + a + a = x + a") =
-    forAll { (x: BitSet, a: N) =>
-      val once = x + a.value
-      (once + a.value) == once
+    forAll { (x: BitSet, a: Int) =>
+      val once = x + a
+      (once + a) == once
     }
 
   property("x - a - a = x - a") =
-    forAll { (x: BitSet, a: N) =>
-      val once = x - a.value
-      (once - a.value) == once
+    forAll { (x: BitSet, a: Int) =>
+      val once = x - a
+      (once - a) == once
     }
 
   property("x.toSet + a == (x + a).toSet") =
-    forAll { (x: BitSet, a: N) =>
-      x.toSet + a.value == (x + a.value).toSet
+    forAll { (x: BitSet, a: Int) =>
+      x.toSet + a == (x + a).toSet
     }
 
   property("x.toSet - a == (x - a).toSet") =
-    forAll { (x: BitSet, a: N) =>
-      x.toSet - a.value == (x - a.value).toSet
+    forAll { (x: BitSet, a: Int) =>
+      x.toSet - a == (x - a).toSet
     }
 
   property("+ is commutative") =
-    forAll { (ns0: List[N]) =>
-      val ns = ns0.map(_.value)
+    forAll { (ns: List[Int]) =>
       BitSet(ns: _*) == BitSet(ns.reverse: _*)
     }
 
   property("- is commutative") =
-    forAll { (x: BitSet, ns0: List[N]) =>
-      val ns = ns0.map(_.value)
+    forAll { (x: BitSet, ns: List[Int]) =>
       ns.foldLeft(x)(_ - _) == ns.reverse.foldLeft(x)(_ - _)
     }
 

--- a/tests/src/test/scala/cats/collections/BitSetTest.scala
+++ b/tests/src/test/scala/cats/collections/BitSetTest.scala
@@ -1,0 +1,192 @@
+package cats.collections
+
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, /*Cogen, */Gen, Properties, Test}
+import Arbitrary.{arbitrary => arb}
+
+object BitSetTest extends Properties("BitSet") {
+
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withMinSuccessfulTests(500)
+
+  case class N(value: Int) {
+    override def toString: String = value.toString
+  }
+
+  implicit val arbN: Arbitrary[N] =
+    Arbitrary(Gen.choose(0, Int.MaxValue).map(N(_)))
+
+  def build(xs: List[N]): BitSet =
+    xs.foldLeft(BitSet.empty)((bs, n) => bs + n.value)
+
+  implicit val arbBitSet: Arbitrary[BitSet] =
+    Arbitrary(arb[List[N]].map(xs => BitSet(xs.map(_.value): _*)))
+
+  property("(x = y) = (x.toSet = y.toSet)") =
+    forAll { (x: BitSet, y: BitSet) =>
+      val xs = x.toSet
+      val ys = y.toSet
+      ((x == y) == (xs == ys)) :| s"($x == $y) == ($xs == $ys)"
+    }
+
+  property("x.toSet == x.iterator.toSet") =
+    forAll { (x: BitSet) =>
+      (x.toSet == x.iterator.toSet) :| s"$x toSet == iterator.toSet"
+    }
+
+  property("BitSet(set: _*).toSet = set") =
+    forAll { (ns0: Set[N]) =>
+      val ns = ns0.map(_.value)
+      val x = BitSet(ns.toList: _*)
+      x.toSet == ns && ns.forall(x(_))
+    }
+
+  property("BitSet(x.toSet: _*) = x") =
+    forAll { (x: BitSet) =>
+      val y = BitSet(x.iterator.toList: _*)
+      x == y
+    }
+
+  property("x.iterator.size = x.size") =
+    forAll { (x: BitSet) =>
+      x.iterator.size == x.size
+    }
+
+  property("(x = y) = (x.## = y.##)") =
+    forAll { (x: BitSet, y: BitSet) =>
+      (x == y) == (x.## == y.##) // only approximately true
+    }
+
+  property("x.compact = x") =
+    forAll { (x: BitSet) =>
+      x.compact == x
+    }
+  property("x.isEmpty == (x.compact eq BitSet.Empty)") =
+    forAll { (x: BitSet) =>
+      (x.isEmpty == (x.compact eq BitSet.Empty)) :| s"$x isEmpty but not compact to Empty"
+    }
+
+  property("x.isEmpty = (x.size = 0)") =
+    forAll { (x: BitSet) =>
+      x.isEmpty == (x.size == 0)
+    }
+
+  property("x.iterator.forall(x(_))") =
+    forAll { (x: BitSet) =>
+      x.iterator.forall(x(_))
+    }
+
+  property("(x + a)(a)") =
+    forAll { (x: BitSet, a: N) =>
+      val y = x + a.value
+      y(a.value) :| s"$y(${a.value})"
+    }
+
+  property("!(x - a)(a)") =
+    forAll { (x: BitSet, a: N) =>
+      !(x - a.value)(a.value)
+    }
+
+  property("x + a - a == x - a") =
+    forAll { (x: BitSet, a: N) =>
+      ((x + a.value) - a.value) == (x - a.value)
+    }
+
+  property("x + a + a = x + a") =
+    forAll { (x: BitSet, a: N) =>
+      val once = x + a.value
+      (once + a.value) == once
+    }
+
+  property("x - a - a = x - a") =
+    forAll { (x: BitSet, a: N) =>
+      val once = x - a.value
+      (once - a.value) == once
+    }
+
+  property("x.toSet + a == (x + a).toSet") =
+    forAll { (x: BitSet, a: N) =>
+      x.toSet + a.value == (x + a.value).toSet
+    }
+
+  property("x.toSet - a == (x - a).toSet") =
+    forAll { (x: BitSet, a: N) =>
+      x.toSet - a.value == (x - a.value).toSet
+    }
+
+  property("+ is commutative") =
+    forAll { (ns0: List[N]) =>
+      val ns = ns0.map(_.value)
+      BitSet(ns: _*) == BitSet(ns.reverse: _*)
+    }
+
+  property("- is commutative") =
+    forAll { (x: BitSet, ns0: List[N]) =>
+      val ns = ns0.map(_.value)
+      ns.foldLeft(x)(_ - _) == ns.reverse.foldLeft(x)(_ - _)
+    }
+
+  property("x | x = x") =
+    forAll { (x: BitSet) =>
+      (x | x) == x
+    }
+
+  property("x | Empty = x") =
+    forAll { (x: BitSet) =>
+      val y = x | BitSet.empty
+      (y == x) :| s"$y ==\n$x"
+    }
+
+  property("x | y = y | x") =
+    forAll { (x: BitSet, y: BitSet) =>
+      try {
+        val lhs = x | y
+        val rhs = y | x
+        (lhs == rhs) :| s"$lhs == $rhs"
+      } catch { case (e: Throwable) => e.printStackTrace; throw e }
+    }
+
+  property("(x | y) | z = x | (y | z)") =
+    forAll { (x: BitSet, y: BitSet, z: BitSet) =>
+      try {
+        val lhs = ((x | y) | z).compact
+        val rhs = (x | (y | z)).compact
+        (lhs == rhs) :| s"$lhs == $rhs"
+      } catch { case (e: Throwable) => e.printStackTrace; throw e }
+    }
+
+  property("x & x = x") =
+    forAll { (x: BitSet) =>
+      val y = x & x
+      (y == x) :| s"$y ==\n$x"
+    }
+
+  property("x & Empty = Empty") =
+    forAll { (x: BitSet) =>
+      (x & BitSet.empty) == BitSet.empty
+    }
+
+  property("x & y = y & x") =
+    forAll { (x: BitSet, y: BitSet) =>
+      (x & y) == (y & x)
+    }
+
+  property("(x & y) & z = x & (y & z)") =
+    forAll { (x: BitSet, y: BitSet, z: BitSet) =>
+      ((x & y) & z) == (x & (y & z))
+    }
+
+  property("(x & (y | z) = (x & y) | (x & z)") =
+    forAll { (x: BitSet, y: BitSet, z: BitSet) =>
+      val lhs = x & (y | z)
+      val rhs = (x & y) | (x & z)
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+
+  property("x.iterator.toList.reverse = x.reverseIterator.toList") =
+    forAll { (x: BitSet) =>
+      val lhs = x.iterator.toList.reverse
+      val rhs = x.reverseIterator.toList
+      (lhs == rhs) :| s"$lhs == $rhs"
+    }
+}


### PR DESCRIPTION
This is an implementation of a fast immutable BitSet (based on a Tree and `Array[Long]`) that @non and I did about a year back.

Here are some benchmarks:
```
[info] Benchmark                      (density)  (exponent)  Mode  Cnt   Score    Error  Units
[info] BitSetBenchmarks.buildCcbs           0.5          10  avgt    3   4.577 ±  4.389  us/op
[info] BitSetBenchmarks.buildIset           0.5          10  avgt    3  81.805 ± 30.429  us/op
[info] BitSetBenchmarks.buildSci            0.5          10  avgt    3  65.580 ± 38.807  us/op
[info] BitSetBenchmarks.buildScm            0.5          10  avgt    3  90.134 ± 20.532  us/op
[info] BitSetBenchmarks.foldIntoCcbs        0.5          10  avgt    3  25.780 ±  2.740  us/op
[info] BitSetBenchmarks.foldIntoIset        0.5          10  avgt    3  84.137 ±  5.968  us/op
[info] BitSetBenchmarks.foldIntoSci         0.5          10  avgt    3  42.205 ±  4.332  us/op
[info] BitSetBenchmarks.foldIntoScm         0.5          10  avgt    3   8.769 ±  0.066  us/op
[info] BitSetBenchmarks.lookupCcbs          0.5          10  avgt    3   0.703 ±  0.112  us/op
[info] BitSetBenchmarks.lookupIset          0.5          10  avgt    3   1.206 ±  0.082  us/op
[info] BitSetBenchmarks.lookupSci           0.5          10  avgt    3   0.839 ±  0.140  us/op
[info] BitSetBenchmarks.lookupScm           0.5          10  avgt    3   0.824 ±  0.173  us/op
[info] BitSetBenchmarks.mergeCcbs           0.5          10  avgt    3   0.045 ±  0.006  us/op
[info] BitSetBenchmarks.mergeIset           0.5          10  avgt    3  14.797 ±  2.277  us/op
[info] BitSetBenchmarks.mergeSci            0.5          10  avgt    3   0.141 ±  0.252  us/op
[info] BitSetBenchmarks.mergeScm            0.5          10  avgt    3   0.057 ±  0.007  us/op
```

where you can see a comparison to `immutable.BitSet  = Sci`, `mutable.BitSet = Scm` and `immutable.Set[Int] = Iset`. As you can see, the performance the best except for fold, where mutable wins. But otherwise *this implementation beats all the rest*.

This code needs comments, and we should add some instances, e.g. `CommutativeMonoid[BitSet]`, `Semiring[BitSet]`, `GenBool[BitSet]`.

Do you think this is suitable for inclusion with some improvements @larsrh ?