### PR TITLE
Add Show instance and fromFoldable to AvlSet

### DIFF
--- a/core/src/main/scala/cats/collections/Set.scala
+++ b/core/src/main/scala/cats/collections/Set.scala
@@ -295,7 +295,7 @@ sealed abstract class AvlSet[A] {
   }
 
   override def toString: String =
-    "Set(" + Foldable[List].intercalate(toList.map(_.toString), ",") + ")"
+    "AvlSet(" + Foldable[List].intercalate(toList.map(_.toString), ", ") + ")"
 
   // So yeah. we had to make a decision, either we have to make this
   // structure Key/Value pairs even when we don't always need a value
@@ -427,6 +427,6 @@ trait AvlSetInstances {
 
   implicit def showSet[A: Show]: Show[AvlSet[A]] = new Show[AvlSet[A]] {
     override def show(t: AvlSet[A]): String =
-      t.toIterator.map(_.show).mkString("Set(", ",", ")")
+      t.toIterator.map(_.show).mkString("AvlSet(", ", ", ")")
   }
 }

--- a/core/src/main/scala/cats/collections/Set.scala
+++ b/core/src/main/scala/cats/collections/Set.scala
@@ -347,6 +347,12 @@ object AvlSet extends AvlSetInstances {
     as.foldLeft[AvlSet[A]](empty)(_ + _)
 
   /**
+    * Create a set from any collection of elements which has a [[cats.Foldable]] instance.
+    */
+  def fromFoldable[F[_], A: Order](as: F[A])(implicit fa: Foldable[F]): AvlSet[A] =
+    fa.foldLeft[A, AvlSet[A]](as, empty)(_ + _)
+
+  /**
    * The empty set.
    */
   def empty[A]: AvlSet[A] = BTNil()
@@ -417,5 +423,10 @@ trait AvlSetInstances {
   implicit def eqSet[A: Eq]: Eq[AvlSet[A]] = new Eq[AvlSet[A]] {
     override def eqv(x: AvlSet[A], y: AvlSet[A]): Boolean =
       iteratorEq(x.toIterator, y.toIterator)
+  }
+
+  implicit def showSet[A: Show]: Show[AvlSet[A]] = new Show[AvlSet[A]] {
+    override def show(t: AvlSet[A]): String =
+      t.toIterator.map(_.show).mkString("AvlSet(", ", ", ")")
   }
 }

--- a/core/src/main/scala/cats/collections/Set.scala
+++ b/core/src/main/scala/cats/collections/Set.scala
@@ -427,6 +427,6 @@ trait AvlSetInstances {
 
   implicit def showSet[A: Show]: Show[AvlSet[A]] = new Show[AvlSet[A]] {
     override def show(t: AvlSet[A]): String =
-      t.toIterator.map(_.show).mkString("AvlSet(", ", ", ")")
+      t.toIterator.map(_.show).mkString("Set(", ",", ")")
   }
 }

--- a/tests/src/test/scala/cats/collections/SetSpec.scala
+++ b/tests/src/test/scala/cats/collections/SetSpec.scala
@@ -1,6 +1,7 @@
 package cats.collections
 package tests
 
+import cats.Show
 import cats.collections.arbitrary.set._
 import cats.kernel.Eq
 import cats.tests.CatsSuite
@@ -114,5 +115,9 @@ class SetSpec extends CatsSuite {
     val xt = AvlSet.fromFoldable(xs)
 
     xt.toScalaSet should be(xs.toSet)
+  })
+
+  test("Show instance is consistent with toString") (forAll{ (as: AvlSet[Int]) =>
+    as.toString should be(Show[AvlSet[Int]].show(as))
   })
 }

--- a/tests/src/test/scala/cats/collections/SetSpec.scala
+++ b/tests/src/test/scala/cats/collections/SetSpec.scala
@@ -109,4 +109,10 @@ class SetSpec extends CatsSuite {
 
     (xt map f).toScalaSet should be(xs map f)
   })
+
+  test("fromFoldable works") (forAll{ (xs: List[Int]) =>
+    val xt = AvlSet.fromFoldable(xs)
+
+    xt.toScalaSet should be(xs.toSet)
+  })
 }


### PR DESCRIPTION
This PR adds two small convenience features to `AvlSet`:
1. An instance of `Show`, implementation based on the one `cats-core` defines for Scala's `Set`
2. A `fromFoldable` on the companion object allowing to construct `AvlSet`s from more collections than just `List`, for example `Chain`.