### PR TITLE
Add one and fromRange methods for creating Diet

### DIFF
--- a/core/src/main/scala/cats/collections/Diet.scala
+++ b/core/src/main/scala/cats/collections/Diet.scala
@@ -277,6 +277,16 @@ sealed abstract class Diet[A] {
 object Diet {
   def empty[A]: Diet[A] = EmptyDiet()
 
+  /**
+   * Create a Diet that contains only a single `A` element.
+   */
+  def one[A](a: A): Diet[A] = DietNode(Range(a, a), empty, empty)
+
+  /**
+   * Create a Diet that consists of a single range of `A` elements.
+   */
+  def fromRange[A](range: Range[A]): Diet[A] = DietNode(range, empty, empty)
+
   private[collections] case class DietNode[A](focus: Range[A], left: Diet[A], right: Diet[A]) extends Diet[A] {
     override val isEmpty: Boolean = false
   }

--- a/tests/src/test/scala/cats/collections/DietSpec.scala
+++ b/tests/src/test/scala/cats/collections/DietSpec.scala
@@ -235,6 +235,28 @@ class DietSpec extends CatsSuite {
     assert(invariant(rs.toDiet))
   })
 
+  test("one and fromRange are consistent")(forAll { (x: Int) =>
+    Diet.fromRange(Range(x, x)) should ===(Diet.one(x))
+  })
+
+  test("fromRange contains consistent with Range contains")(forAll { (x: Byte, y: Byte, z: Byte) =>
+    val range = if (x < y) Range(x, y) else Range(y, x)
+    Diet.fromRange(range).contains(z) should ===(range.contains(z))
+  })
+
+  test("one and contains are consistent")(forAll { (x: Int, y: Int) =>
+    Diet.one(x).contains(y) should ===(x == y)
+  })
+
+  test("one toList")(forAll { (x: Int) =>
+    Diet.one(x).toList should ===(x :: Nil)
+  })
+
+  test("range toList")(forAll { (x: Byte, y: Byte) =>
+    val range = if (x < y) Range(x, y) else Range(y, x)
+    Diet.fromRange(range).toList should ===(range.toList)
+  })
+
   checkAll("Diet[Int]", CommutativeMonoidTests[Diet[Int]].commutativeMonoid)
   checkAll("Diet[Int]", RingLaws[Diet[Int]].semiring)
   checkAll("Diet[Int]", LogicLaws[Diet[Int]].generalizedBool)


### PR DESCRIPTION
Since the `Diet` constructors are package private, these methods can't be written in their current form outside of `cats.collections`. You can mimic them by calling `Diet.empty` and adding elements to it, but it is a little more verbose (and it applies some unnecessary `Order` and `Discrete` constraints).