### PR TITLE
Implement Heap.pop

### DIFF
--- a/core/src/main/scala/cats/collections/Heap.scala
+++ b/core/src/main/scala/cats/collections/Heap.scala
@@ -130,6 +130,15 @@ sealed abstract class Heap[A] {
     Heap.heapify(a)
 
   /**
+   * Remove the min element from the heap (the root) and return it along with the updated heap.
+   * Order O(log n)
+   */
+  def pop(implicit order: Order[A]): Option[(A, Heap[A])] = this match {
+    case Branch(m, l, r) => Some((m, bubbleRootDown(mergeChildren(l, r))))
+    case Leaf()          => None
+  }
+
+  /**
    * Remove the min element from the heap (the root).
    * Order O(log n)
    */

--- a/core/src/main/scala/cats/collections/PairingHeap.scala
+++ b/core/src/main/scala/cats/collections/PairingHeap.scala
@@ -161,6 +161,15 @@ sealed abstract class PairingHeap[A] {
   }
 
   /**
+   * Remove the min element from the heap (the root) and return it along with the updated heap.
+   * Order O(log n)
+   */
+  def pop(implicit order: Order[A]): Option[(A, PairingHeap[A])] = this match {
+    case Tree(m, subtrees) => Some((m, combineAll(subtrees)))
+    case Leaf()            => None
+  }
+
+  /**
    * if not empty, remove the min, else return empty
    * this is thought to be O(log N) (but not proven to be so)
    */

--- a/tests/src/test/scala/cats/collections/HeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/HeapSpec.scala
@@ -120,6 +120,24 @@ class HeapSpec extends CatsSuite {
     assert(Heap.empty[Int].remove == Heap.empty[Int])
   }
 
+  test("pop and remove return the same heap") {
+    forAll { (heap: Heap[Int]) =>
+      val heap1 = heap.remove
+      heap.pop.map(_._2) match {
+        case Some(heap2) => assert(Order[Heap[Int]].eqv(heap1, heap2))
+        case None => assert(heap1.isEmpty)
+      }
+    }
+  }
+
+  test("pop returns the minimum element") {
+    forAll { (heap: Heap[Int]) =>
+      val min1 = heap.pop.map(_._1)
+      val min2 = heap.minimumOption
+      assert(min1 == min2)
+    }
+  }
+
   test("size is consistent with isEmpty/nonEmpty") {
     forAll { (heap: Heap[Int]) =>
       assert(heap.isEmpty == (heap.size == 0))

--- a/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
+++ b/tests/src/test/scala/cats/collections/PairingHeapSpec.scala
@@ -213,4 +213,22 @@ class PairingHeapSpec extends CatsSuite {
       assert(PairingHeap.takeLargest(as, k).toList.reverse == as.toList.sorted.reverse.take(k))
     }
   }
+
+  test("pop and remove return the same heap") {
+    forAll { (heap: PairingHeap[Int]) =>
+      val heap1 = heap.remove
+      heap.pop.map(_._2) match {
+        case Some(heap2) => assert(Order[PairingHeap[Int]].eqv(heap1, heap2))
+        case None => assert(heap1.isEmpty)
+      }
+    }
+  }
+
+  test("pop returns the minimum element") {
+    forAll { (heap: PairingHeap[Int]) =>
+      val min1 = heap.pop.map(_._1)
+      val min2 = heap.minimumOption
+      assert(min1 == min2)
+    }
+  }
 }


### PR DESCRIPTION
To fix this: https://github.com/typelevel/cats-collections/issues/193

I implemented `Heap.pop`. Since `Heap.remove` can be derived from `Heap.pop`, I changed the implementation of `remove` to reuse `pop`.