### PR TITLE
UseParallelGC instead of UseConcMarkSweepGC

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -4,5 +4,4 @@
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
--XX:+CMSClassUnloadingEnabled
--XX:+UseConcMarkSweepGC
+-XX:+UseParallelGC


### PR DESCRIPTION
UseConcMarkSweepGC is deprecated in newwer JVM's