### PR TITLE
minor cleanup to remove deprecation on 2.13

### DIFF
--- a/core/src/main/scala/cats/collections/Diet.scala
+++ b/core/src/main/scala/cats/collections/Diet.scala
@@ -274,7 +274,7 @@ sealed abstract class Diet[A] {
     }
 
   def toIterator: Iterator[Range[A]] = this match {
-    case EmptyDiet() => Stream.empty[Range[A]].iterator
+    case EmptyDiet() => Iterator.empty[Range[A]]
     case DietNode(focus, left, right) =>
       left
         .toIterator

--- a/core/src/main/scala/cats/collections/Diet.scala
+++ b/core/src/main/scala/cats/collections/Diet.scala
@@ -274,7 +274,7 @@ sealed abstract class Diet[A] {
     }
 
   def toIterator: Iterator[Range[A]] = this match {
-    case EmptyDiet() => Iterator.empty[Range[A]]
+    case EmptyDiet() => Iterator.empty
     case DietNode(focus, left, right) =>
       left
         .toIterator


### PR DESCRIPTION
I noticed Diet needlessly makes a stream to get an empty iterator.

We can directly make an empty iterator.