### PR TITLE
Move latest JDK version to 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.14, 2.13.6, 3.0.1]
-        java: [adopt@1.8, adopt@1.11, adopt@1.15]
+        java: [adopt@1.8, adopt@1.11, adopt@1.16]
         ci: [validateJS, validateJVM]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val buildSettings = Seq(
 ThisBuild / crossScalaVersions := Seq(Scala212, Scala213, Scala3)
 ThisBuild / scalaVersion := Scala212
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
-ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11", "adopt@1.15")
+ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11", "adopt@1.16")
 ThisBuild / githubWorkflowArtifactUpload := false
 ThisBuild / githubWorkflowBuildMatrixAdditions +=
   "ci" -> List("validateJS", "validateJVM")


### PR DESCRIPTION
Change latest version of JDK to run CI on from 15 to 16 to allow checks
on latest to the date one (stated to be supported by scalac 2.12.4 and 2.13.6)