### PR TITLE
Cleanup Scalafmt things

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,3 +9,4 @@ rewrite.rules = [AvoidInfix, SortImports, RedundantParens, SortModifiers]
 newlines.afterCurlyLambda = preserve
 docstrings.style = Asterisk
 docstrings.oneline = unfold
+runner.dialect = "Scala213Source3"

--- a/core/src/main/scala/cats/collections/TreeList.scala
+++ b/core/src/main/scala/cats/collections/TreeList.scala
@@ -648,7 +648,6 @@ object TreeList extends TreeListInstances0 {
     def toIterator: Iterator[A] = new TreeListIterator(this)
     def toReverseIterator: Iterator[A] = new TreeListReverseIterator(this)
 
-    // format: off
     def updatedOrThis[A1 >: A](idx: Long, a: A1): TreeList[A1] = {
       @tailrec
       def loop(idx: Long, treeList: List[Tree[Nat, A1]], front: List[Tree[Nat, A1]]): TreeList[A1] =
@@ -665,7 +664,6 @@ object TreeList extends TreeListInstances0 {
 
       loop(idx, treeList, Nil)
     }
-    // format: on
 
     def foldMap[B: Monoid](fn: A => B): B =
       Monoid[B].combineAll(treeList.map(_.foldMap(fn)))


### PR DESCRIPTION
In `3.0.3` version of Scalafmt was fixed behaviour that I've described in PR, see https://github.com/typelevel/cats-collections/pull/414#discussion_r702462488. So we can remove custom off of formatting in `TreeList`. Also, Scalafmt has added a deprecation of default dialect, so it's needed to set it explicit to prevent warnings.