### PR TITLE
Remove `-Xcheckinit` compiler flag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -316,7 +316,6 @@ lazy val compilerFlags = Seq(
           "-language:higherKinds", // Allow higher-kinded types
           "-language:implicitConversions", // Allow definition of implicit functions called views
           "-unchecked", // Enable additional warnings where generated code depends on assumptions.
-          "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
           "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
           "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
           "-Xlint:delayedinit-select", // Selecting member of DelayedInit.


### PR DESCRIPTION
We learned in https://github.com/typelevel/cats-effect/pull/2540 that this can have serious consequences for performance.

If this flag is important, maybe you can find a way to enable it for tests but disable for release?