### PR TITLE
Add `BitSet.fromScalaRange`

### DIFF
--- a/core/src/main/scala/cats/collections/BitSet.scala
+++ b/core/src/main/scala/cats/collections/BitSet.scala
@@ -371,7 +371,7 @@ object BitSet {
   /**
    * Construct an immutable bitset from the given integer [[scala.collection.immutable.Range]].
    */
-  def apply(xs: scala.collection.immutable.Range): BitSet =
+  def fromScalaRange(xs: scala.collection.immutable.Range): BitSet =
     if (xs.isEmpty) Empty
     else {
       var bs = newEmpty(0)

--- a/core/src/main/scala/cats/collections/BitSet.scala
+++ b/core/src/main/scala/cats/collections/BitSet.scala
@@ -369,6 +369,19 @@ object BitSet {
     }
 
   /**
+   * Construct an immutable bitset from the given integer [[scala.collection.immutable.Range]].
+   */
+  def apply(xs: scala.collection.immutable.Range): BitSet =
+    if (xs.isEmpty) Empty
+    else {
+      var bs = newEmpty(0)
+      xs.foreach { i =>
+        bs = bs.mutableAdd(i)
+      }
+      bs
+    }
+
+  /**
    * Given a value (`n`), and offset (`o`) and a height (`h`), compute the array index used to store the given value's
    * bit.
    */

--- a/tests/src/test/scala/cats/collections/BitSetTest.scala
+++ b/tests/src/test/scala/cats/collections/BitSetTest.scala
@@ -375,11 +375,11 @@ object BitSetTest extends Properties("BitSet") {
     law(x, y, "--")(_ -- _)
   }
 
-  property("Range-constructor consistent with varargs-constructor") =
+  property("Bitset.fromScalaRange consistent with BitSet(...)") =
     forAll(Gen.chooseNum(0, Short.MaxValue.toInt), Gen.chooseNum(0, Short.MaxValue.toInt)) { (start, stop) =>
       forAll(Gen.chooseNum(1, (stop - start).abs.max(1))) { step =>
         val xs = start until stop by step
-        val lhs = BitSet(xs)
+        val lhs = BitSet.fromScalaRange(xs)
         val rhs = BitSet(xs: _*)
         (lhs == rhs) :| s"$lhs == $rhs"
       }

--- a/tests/src/test/scala/cats/collections/BitSetTest.scala
+++ b/tests/src/test/scala/cats/collections/BitSetTest.scala
@@ -375,4 +375,14 @@ object BitSetTest extends Properties("BitSet") {
     law(x, y, "--")(_ -- _)
   }
 
+  property("Range-constructor consistent with varargs-constructor") =
+    forAll(Gen.chooseNum(0, Short.MaxValue), Gen.chooseNum(0, Short.MaxValue)) { (start, stop) =>
+      forAll(Gen.chooseNum(1, (stop - start).abs.max(1))) { step =>
+        val xs = start until stop by step
+        val lhs = BitSet(xs)
+        val rhs = BitSet(xs: _*)
+        (lhs == rhs) :| s"$lhs == $rhs"
+      }
+    }
+
 }

--- a/tests/src/test/scala/cats/collections/BitSetTest.scala
+++ b/tests/src/test/scala/cats/collections/BitSetTest.scala
@@ -376,7 +376,7 @@ object BitSetTest extends Properties("BitSet") {
   }
 
   property("Range-constructor consistent with varargs-constructor") =
-    forAll(Gen.chooseNum(0, Short.MaxValue), Gen.chooseNum(0, Short.MaxValue)) { (start, stop) =>
+    forAll(Gen.chooseNum(0, Short.MaxValue.toInt), Gen.chooseNum(0, Short.MaxValue.toInt)) { (start, stop) =>
       forAll(Gen.chooseNum(1, (stop - start).abs.max(1))) { step =>
         val xs = start until stop by step
         val lhs = BitSet(xs)


### PR DESCRIPTION
This will be helpful in idna4s /cc @isomarcte. The existing constructor forces to initialize a collection of integers.