### PR TITLE
Fix warnings in Diet

### DIFF
--- a/bench/src/main/scala/cats/collections/bench/DietToIteratorRegressionBench.scala
+++ b/bench/src/main/scala/cats/collections/bench/DietToIteratorRegressionBench.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package cats.collections
+package bench
+
+import org.openjdk.jmh.annotations._
+import scala.util.Random
+
+@State(Scope.Benchmark)
+class DietToIteratorRegressionBench {
+  final private val randomSeed = 497169389666431579L
+
+  @Param(Array("100", "1000", "10000"))
+  var size: Int = _
+
+  @Param(Array("0", "8", "16", "24"))
+  var shiftBits: Int = _
+
+  var diet: Diet[Int] = Diet.empty[Int]
+
+  @Setup
+  def setup(): Unit = {
+    val random = new Random(randomSeed)
+
+    var i = 0
+    while (i < size) {
+      val s = random.nextInt()
+      val e = s + (random.nextInt() >> shiftBits)
+
+      diet += Range(s, e)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def toIterator(): Unit = {
+    diet.toIterator.foreach(Function.const(()))
+  }
+}

--- a/mima.sbt
+++ b/mima.sbt
@@ -1,0 +1,8 @@
+import com.typesafe.tools.mima.core.ProblemFilters._
+import com.typesafe.tools.mima.core._
+
+ThisBuild / mimaBinaryIssueFilters ++= Seq(
+  // Methods and other things defined as `private [collections]` and therefore
+  // not supposed to be referenced externally.
+  exclude[IncompatibleMethTypeProblem]("cats.collections.Diet.splitMax")
+)

--- a/tests/src/test/scala/cats/collections/AnotherDietSuite.scala
+++ b/tests/src/test/scala/cats/collections/AnotherDietSuite.scala
@@ -66,4 +66,11 @@ class AnotherDietSuite extends DisciplineSuite {
     d2.toList.foreach(elem => assert(!d.contains(elem)))
     d1.toList.foreach(elem => assert(d2.contains(elem) || d.contains(elem)))
   })
+
+  property("toIterator/toList")(forAll { (d: Diet[Int]) =>
+    assertEquals(
+      d.toIterator.flatMap(_.toIterator).toList,
+      d.toList
+    )
+  })
 }


### PR DESCRIPTION
For #486 (a follow-up to #562).

It was quite a tricky one. Most of the warnings in `Diet` were due to non-exhaustive matches in code like this:
https://github.com/typelevel/cats-collections/blob/4bdcca725d0be64d33a3d6ab1dfcaa958ee611b7/core/src/main/scala/cats/collections/Diet.scala#L50-L52

The root-cause was `EmptyDiet#unapply`:
https://github.com/typelevel/cats-collections/blob/4bdcca725d0be64d33a3d6ab1dfcaa958ee611b7/core/src/main/scala/cats/collections/Diet.scala#L319-L320

Apparently, the compiler could not figure out that `case EmptyDiet() =>` covers everything besides `DietNode`.
However there was a pitfall hidden: at first glance it might seem that it could be a solution to use the `EmptyDiet` object reference directly, i.e.:
```scala
this match {
  case EmptyDiet =>
  case DietNode(_, _, _) =>
```
However it does not work since `Diet` is invariant in its `[A]` whereas `EmptyDiet extends Diet[Nothing]`.
Therefore, the compiler rejects using descendants of `Diet[Nothing]` where `Diet[A]` is required.

A better option would be matching on the `EmptyDiet` object type directly, i.e.:
```scala
this match {
  case _: EmptyDiet.type =>
  case DietNode(_, _, _) =>
}
```
And it worked just fine for Scala2 (both 2.12 and 2.13), but stops working for Scala3 (because it is way better and more precise in regards to types, hehe). For more details see lampepfl/dotty#16503.

So the only approach I came up eventually with was introducing `final class EmptyDiet[A] extends Diet[A]` and making sure it has a singleton instance. Hence the most of the fixes in this PR.